### PR TITLE
Attempt at addressing timeout issues for Azure ubuntu repos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,9 +26,10 @@ jobs:
       - name: Set up non-Python dependences (Linux)
         if: runner.os == 'Linux'
         run: |
-          sudo apt-get install libxcb-xinerama0
-          sudo apt-get install libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xfixes0
-          sudo apt-get install libpulse-mainloop-glib0
+          sudo apt-get -o Acquire::Retries=3 update
+          sudo apt-get -o Acquire::Retries=3 install libxcb-xinerama0
+          sudo apt-get -o Acquire::Retries=3 install libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xfixes0
+          sudo apt-get -o Acquire::Retries=3 install libpulse-mainloop-glib0
         # sudo apt-get install libgfortran4
         # echo "QT_DEBUG_PLUGINS=1" >> $GITHUB_ENV
 


### PR DESCRIPTION
Recent GH jobs on Ubuntu , e.g. https://github.com/easyScience/easyDiffractionApp/runs/2902065750?check_suite_focus=true
fail due to failure to reach azure stores for ubuntu.
This seems to be a common issue on GH Actions, and although no proper solution is mentioned, workarounds are known.
https://github.com/actions/virtual-environments/issues/675

This PR implements one of those workarounds and it seems to fix the current failures for easyDiffractionApp builds