### PR TITLE
Windows calculators

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,7 @@ separator = { macos = ':', ubuntu = ':', windows = ';' }
 dir_suffix = { macos = '.app', ubuntu = '', windows = '' }
 content_suffix = { macos = 'Contents/MacOS/', ubuntu = '', windows = '' }
 libs = { macos = 'libsDarwin', ubuntu = 'libsLinux', windows = 'libsWin32' }
+missing_calculator_libs = { macos = [], ubuntu = [], windows = ['GSASII.libs', 'CFML.libs'] }
 missing_pyside2_files = { macos = ['libshiboken2.abi3.*.dylib'], ubuntu = [], windows = ['shiboken2.abi3.dll', 'MSVCP140.dll'] }
 missing_pyside2_plugins = { macos = [], ubuntu = ['Qt/plugins/xcbglintegrations'], windows = [] } # EGL and GLX plugins
 missing_other_libraries = {macos = [], ubuntu = [], windows = ['libs/libiomp5md.dll', 'libs/opengl32.dll'] }

--- a/tools/Scripts/FreezeApp.py
+++ b/tools/Scripts/FreezeApp.py
@@ -64,7 +64,8 @@ def copyCalculators():
     data = []
     try:
         message = 'Copy calculator libraries'
-        site_packages_path = site.getsitepackages()[1]
+        # use the last element, since on certain conda installations we get more than one entry
+        site_packages_path = site.getsitepackages()[-1]
         for lib_name in missing_calculator_libs:
             lib_path = os.path.join(site_packages_path, lib_name)
             data.append({'from': lib_path, 'to': lib_name})

--- a/tools/Scripts/FreezeApp.py
+++ b/tools/Scripts/FreezeApp.py
@@ -7,6 +7,7 @@ __version__ = '0.0.1'
 
 import os, sys
 import glob
+import site
 import PySide2, shiboken2
 import cryspy, GSASII
 import easyCore, easyDiffractionLib, easyApp
@@ -43,6 +44,8 @@ def addedData():
         for extra_file in extras:
             data.append({'from': extra_file, 'to': '.'})
 
+    data = data + copyCalculators()
+
     formatted = []
     for element in data:
         formatted.append(f'--add-data={element["from"]}{separator}{element["to"]}')
@@ -55,6 +58,22 @@ def appIcon():
     icon_path = os.path.join(CONFIG.package_name, icon_dir, f'{icon_name}{icon_ext}')
     icon_path = os.path.abspath(icon_path)
     return f'--icon={icon_path}'
+
+def copyCalculators():
+    missing_calculator_libs = CONFIG['ci']['pyinstaller']['missing_calculator_libs'][CONFIG.os]
+    data = []
+    try:
+        message = 'Copy calculator libraries'
+        site_packages_path = site.getsitepackages()[1]
+        for lib_name in missing_calculator_libs:
+            lib_path = os.path.join(site_packages_path, lib_name)
+            data.append({'from': lib_path, 'to': lib_name})
+    except Exception as exception:
+        Functions.printFailMessage(message, exception)
+        sys.exit(1)
+
+    Functions.printSuccessMessage(message)
+    return data
 
 def copyMissingLibs():
     missing_files = CONFIG['ci']['pyinstaller']['missing_pyside2_files'][CONFIG.os]


### PR DESCRIPTION
Extended `data` for pyinstaller to include missing calculator libraries for Windows pyinstaller builds.
Addresses #149 