### PR TITLE
Logic cleanup

### DIFF
--- a/easyDiffractionApp/Gui/Components/ApplicationWindow.qml
+++ b/easyDiffractionApp/Gui/Components/ApplicationWindow.qml
@@ -354,7 +354,7 @@ EaComponents.ApplicationWindow {
         visible: EaGlobals.Variables.appBarCurrentIndex !== 0
 
         model: XmlListModel {
-            xml: ExGlobals.Constants.proxy.statusModelAsXml
+            xml: ExGlobals.Constants.proxy.project.statusModelAsXml
             query: "/root/item"
 
             XmlRole { name: "label"; query: "label/string()" }

--- a/easyDiffractionApp/Gui/Pages/Summary/MainContentReport.qml
+++ b/easyDiffractionApp/Gui/Pages/Summary/MainContentReport.qml
@@ -497,8 +497,8 @@ Item {
                   `<b>Analysis:</b> <a href="${ExGlobals.Constants.appUrl}">${ExGlobals.Constants.appName} v${ExGlobals.Constants.appVersion}</a><br>`,
                   `<b>Structure chart:</b> <a href="${ExGlobals.Variables.chemDoodleStructureChart.info.url}"> ChemDoodle Web Components v${ExGlobals.Variables.chemDoodleStructureChart.info.version}</a><br>`,
                   `<b>Data chart:</b> <a href="${dataChartLibUrl}"> BokehJS v${dataChartLibVersion}</a><br>`,
-                  `<b>Calculation engine:</b> ${ExGlobals.Constants.proxy.statusModelAsObj.calculation}<br>`,
-                  isFitting ? `<b>Minimization:</b> ${ExGlobals.Constants.proxy.statusModelAsObj.minimization}<br>` : '',
+                  `<b>Calculation engine:</b> ${ExGlobals.Constants.proxy.project.statusModelAsObj.calculation}<br>`,
+                  isFitting ? `<b>Minimization:</b> ${ExGlobals.Constants.proxy.project.statusModelAsObj.minimization}<br>` : '',
                   '</div>'
               ]
         return list.join('\n')

--- a/easyDiffractionApp/Logic/Background.py
+++ b/easyDiffractionApp/Logic/Background.py
@@ -11,14 +11,12 @@ from easyDiffractionLib.elements.Backgrounds.Point import PointBackground, Backg
 
 class BackgroundLogic(QObject):
 
-    asObjChanged = Signal('QVariant')
     asXmlChanged = Signal()
 
     def __init__(self, parent):
         super().__init__(parent)
         self.parent = parent
         self._background_as_xml = ""
-        self.asObjChanged.connect(self.onAsObjChanged)
         self.asXmlChanged.connect(self.updateChartBackground)
         self._bg_types = {
             'point': {
@@ -37,16 +35,16 @@ class BackgroundLogic(QObject):
         return itm
 
     def removeAllPoints(self):
-        self.asObjChanged.disconnect()
         for point_name in self._background_as_obj.names:
-            self.removePoint(point_name)
-        self.asObjChanged.connect(self.onAsObjChanged)
-        self.onAsObjChanged()
+            self.removePoint(point_name, silently=True)
+        self._background_as_obj = self._background_obj()
+        self._setAsXml()
 
     def onAsObjChanged(self):
         print(f"***** onAsObjChanged")
         self._background_as_obj = self._background_obj()
         self._setAsXml()
+        self.parent.updateBackground(self._background_as_obj)
 
     def _setAsXml(self):
         if self._background_as_obj is None:
@@ -74,7 +72,7 @@ class BackgroundLogic(QObject):
         self._background_as_obj.append(min_point)
         self._background_as_obj.append(max_point)
 
-        self.asObjChanged.emit(self._background_as_obj)
+        self.onAsObjChanged()
 
     def initializeContainer(self, experiment_name: str = 'current_exp', container_type=None):
         container = None
@@ -94,7 +92,7 @@ class BackgroundLogic(QObject):
         point = BackgroundPoint.from_pars(x=x, y=y)
         self._background_as_obj.append(point)
         if not silently:
-            self.asObjChanged.emit(self._background_as_obj)
+            self.onAsObjChanged()
 
     def addPoints(self, xarray, yarray):
         if self._background_as_obj is None:
@@ -103,7 +101,7 @@ class BackgroundLogic(QObject):
             print(f"+ add background point ({x}, {y})")
             point = BackgroundPoint.from_pars(x=x, y=y)
             self._background_as_obj.append(point)
-        self.asObjChanged.emit(self._background_as_obj)
+        self.onAsObjChanged()
 
     def addDefaultPoint(self):
         print(f"+ add default background point")
@@ -113,13 +111,13 @@ class BackgroundLogic(QObject):
             x = self._background_as_obj.x_sorted_points[-1] + 10.0
         self.addPoint(x, y)
 
-    def removePoint(self, point_name: str):
+    def removePoint(self, point_name: str, silently: bool = False):
         print(f"+ removeBackgroundPoint for point_name: {point_name}")
         point_names = self._background_as_obj.names
         point_index = point_names.index(point_name)
         del self._background_as_obj[point_index]
-
-        self.asObjChanged.emit(self._background_as_obj)
+        if not silently:
+            self.onAsObjChanged()
 
     def updateChartBackground(self):
         if self._background_as_obj is None:

--- a/easyDiffractionApp/Logic/Background.py
+++ b/easyDiffractionApp/Logic/Background.py
@@ -30,7 +30,7 @@ class BackgroundLogic(QObject):
         self._background_as_obj = self._background_obj()
 
     def _background_obj(self):
-        bgs = self.parent.l_sample._sample.pattern.backgrounds
+        bgs = self.parent.sample().pattern.backgrounds
         itm = None
         if len(bgs) > 0:
             itm = bgs[0]
@@ -80,7 +80,7 @@ class BackgroundLogic(QObject):
         container = None
         if container_type is None:
             container = self._bg_types[self._default_type]['container']
-        self.parent.l_sample._sample.pattern.backgrounds.append(
+        self.parent.sample().pattern.backgrounds.append(
             # TODO we will be the current exp name and use it here.
             container(linked_experiment=experiment_name)
         )
@@ -124,6 +124,6 @@ class BackgroundLogic(QObject):
     def updateChartBackground(self):
         if self._background_as_obj is None:
             return
-        self.parent.l_plotting1d.setBackgroundData(
+        self.parent.setBackgroundData(
                             self._background_as_obj.x_sorted_points,
                             self._background_as_obj.y_sorted_points)

--- a/easyDiffractionApp/Logic/Background.py
+++ b/easyDiffractionApp/Logic/Background.py
@@ -30,7 +30,7 @@ class BackgroundLogic(QObject):
         self._background_as_obj = self._background_obj()
 
     def _background_obj(self):
-        bgs = self.parent.sample().pattern.backgrounds
+        bgs = self.parent.sampleBackgrounds()
         itm = None
         if len(bgs) > 0:
             itm = bgs[0]
@@ -80,7 +80,7 @@ class BackgroundLogic(QObject):
         container = None
         if container_type is None:
             container = self._bg_types[self._default_type]['container']
-        self.parent.sample().pattern.backgrounds.append(
+        self.parent.sampleBackgrounds().append(
             # TODO we will be the current exp name and use it here.
             container(linked_experiment=experiment_name)
         )

--- a/easyDiffractionApp/Logic/Experiment.py
+++ b/easyDiffractionApp/Logic/Experiment.py
@@ -196,6 +196,13 @@ class ExperimentLogic(QObject):
         self.state._updateCalculatedData()
         return True
 
+    def updateExperimentData(self, name=None):
+            self._experiment_data = self.parent.l_parameters._data.experiments[0]
+            self.experiments = [{'name': name}]
+            self.setCurrentExperimentDatasetName(name)
+            self.setPolarized(self.spin_polarized)
+            self._onExperimentDataAdded()
+
     def experimentLoaded(self, loaded: bool):
         if self._experiment_loaded == loaded:
             return

--- a/easyDiffractionApp/Logic/Experiment.py
+++ b/easyDiffractionApp/Logic/Experiment.py
@@ -20,11 +20,14 @@ from easyApp.Logic.Utils.Utils import generalizePath
 class ExperimentLogic(QObject):
     """
     """
+    # signals controlled by LC
     experimentLoadedChanged = Signal()
     experimentSkippedChanged = Signal()
-    experimentDataChanged = Signal()
-    patternParametersAsObjChanged = Signal()
     clearFrontendState = Signal()
+
+    # signals controlled by our proxy
+    patternParametersAsObjChanged = Signal()
+    structureParametersChanged = Signal()
 
     def __init__(self, parent=None, interface=None):
         super().__init__(parent)
@@ -227,7 +230,7 @@ class ExperimentLogic(QObject):
         self.experimentLoaded(True)
         self.experimentSkipped(False)
         # need to update parameters in all the places.
-        self.parent.l_phase.structureParametersChanged.emit()
+        self.structureParametersChanged.emit()
 
     def addExperimentDataFromXye(self, file_url):
         self._experiment_data = self._loadExperimentData(file_url)
@@ -253,6 +256,7 @@ class ExperimentLogic(QObject):
         self._experiment_data = None
         self.experimentLoaded(False)
         self.experimentSkipped(False)
+        self.parent.clearFrontendState()
 
     def _onExperimentSkippedChanged(self):
         self.parent.updateCalculatedData()

--- a/easyDiffractionApp/Logic/Experiment.py
+++ b/easyDiffractionApp/Logic/Experiment.py
@@ -117,7 +117,7 @@ class ExperimentLogic(QObject):
                 self.parent.setPhaseScale(phase_label, phase_scale)
 
         # Get data
-        data = self.experiments()[0]
+        data = self.parent.experiments()[0]
         # Polarized case
         data.x = np.fromiter(block.find_loop("_pd_meas_2theta"), float)
         data.y = np.fromiter(block.find_loop("_pd_meas_intensity_up"), float)

--- a/easyDiffractionApp/Logic/Experiment.py
+++ b/easyDiffractionApp/Logic/Experiment.py
@@ -60,18 +60,18 @@ class ExperimentLogic(QObject):
 
         # Get experiment type
         # Set default experiment type: powder1DCWunp
-        self.parent.l_sample.experimentType = 'powder1DCWunp'
+        self.parent.setExperimentType('powder1DCWunp')
         # Check if powder1DCWpol
         value = block.find_value("_diffrn_radiation_polarization")
         if value is not None:
-            self.parent.l_sample.experimentType = 'powder1DCWpol'
+            self.parent.setExperimentType('powder1DCWpol')
         # Check if powder1DTOFunp
         # ...
         # Check if powder1DTOFpol
         # ...
 
         # Get diffraction radiation parameters
-        pattern_parameters = self.parent.l_sample._sample.pattern
+        pattern_parameters = self.parent.sample().pattern
         value = block.find_value("_diffrn_radiation_polarization")
         if value is not None:
             pattern_parameters.beam.polarization = float(value)
@@ -80,7 +80,7 @@ class ExperimentLogic(QObject):
             pattern_parameters.beam.efficiency = float(value)
 
         # Get pattern parameters
-        pattern_parameters = self.parent.l_sample._sample.pattern
+        pattern_parameters = self.parent.sample().pattern
         value = block.find_value("_setup_offset_2theta")
         if value is not None:
             pattern_parameters.zero_shift = float(value)
@@ -89,7 +89,7 @@ class ExperimentLogic(QObject):
             pattern_parameters.field = float(value)
 
         # Get instrumental parameters
-        instrument_parameters = self.parent.l_sample._sample.parameters
+        instrument_parameters = self.parent.sample().parameters
         value = block.find_value("_setup_wavelength")
         if value is not None:
             instrument_parameters.wavelength = float(value)
@@ -110,15 +110,15 @@ class ExperimentLogic(QObject):
             instrument_parameters.resolution_y = float(value)
 
         # Get phase parameters
-        sample_phase_labels = self.parent.l_phase.phases.phase_names
+        sample_phase_labels = self.parent.getPhaseNames()
         experiment_phase_labels = list(block.find_loop("_phase_label"))
         experiment_phase_scales = np.fromiter(block.find_loop("_phase_scale"), float)
         for (phase_label, phase_scale) in zip(experiment_phase_labels, experiment_phase_scales):
             if phase_label in sample_phase_labels:
-                self.parent.l_phase.phases[phase_label].scale = phase_scale
+                self.parent.setPhaseScale(phase_label, phase_scale)
 
         # Get data
-        data = self.state._data.experiments[0]
+        data = self.parent.pdata().experiments[0]
         # Polarized case
         data.x = np.fromiter(block.find_loop("_pd_meas_2theta"), float)
         data.y = np.fromiter(block.find_loop("_pd_meas_intensity_up"), float)
@@ -140,7 +140,7 @@ class ExperimentLogic(QObject):
     def _loadExperimentData(self, file_url):
         print("+ _loadExperimentData")
         file_path = generalizePath(file_url)
-        data = self.state._data.experiments[0]
+        data = self.parent.pdata().experiments[0]
         try:
             data.x, data.y, data.e, data.yb, data.eb = np.loadtxt(file_path, unpack=True)
             self.setPolarized(True)
@@ -174,7 +174,7 @@ class ExperimentLogic(QObject):
     def setPolarized(self, polarized: bool):
         if self.spin_polarized == polarized:
             return False
-        current_type = self.parent.l_sample.experimentType
+        current_type = self.parent.experimentType()
         if 'TOF' in current_type:
             return False # no polarized for TOF
 
@@ -191,17 +191,17 @@ class ExperimentLogic(QObject):
             if 'pol' in current_type:
                 current_type = current_type.replace('pol', 'unp')
 
-        self.parent.l_sample.experimentType = current_type
+        self.parent.setExperimentType(current_type)
         # need to recalculate the profile
-        self.state._updateCalculatedData()
+        self.parent.updateCalculatedData()
         return True
 
     def updateExperimentData(self, name=None):
-            self._experiment_data = self.parent.l_parameters._data.experiments[0]
-            self.experiments = [{'name': name}]
-            self.setCurrentExperimentDatasetName(name)
-            self.setPolarized(self.spin_polarized)
-            self._onExperimentDataAdded()
+        self._experiment_data = self.parent.pdata().experiments[0]
+        self.experiments = [{'name': name}]
+        self.setCurrentExperimentDatasetName(name)
+        self.setPolarized(self.spin_polarized)
+        self._onExperimentDataAdded()
 
     def experimentLoaded(self, loaded: bool):
         if self._experiment_loaded == loaded:
@@ -216,15 +216,15 @@ class ExperimentLogic(QObject):
         self.experimentSkippedChanged.emit()
 
     def experimentDataAsObj(self):
-        return [{'name': experiment.name} for experiment in self.state._data.experiments]
+        return [{'name': experiment.name} for experiment in self.parent.pdata().experiments]
 
     def _setExperimentDataAsXml(self):
         self._experiment_data_as_xml = dicttoxml(self.experiments, attr_type=True).decode()  # noqa: E501
 
     def addExperimentDataFromCif(self, file_url):
         self._experiment_data = self._loadExperimentCif(file_url)
-        self.state._data.experiments[0].name = pathlib.Path(file_url).stem
-        self.experiments = [{'name': experiment.name} for experiment in self.state._data.experiments]
+        self.parent.setExperimentName(pathlib.Path(file_url).stem)
+        self.experiments = [{'name': experiment.name} for experiment in self.parent.pdata().experiments]
         self.experimentLoaded(True)
         self.experimentSkipped(False)
         # need to update parameters in all the places.
@@ -232,8 +232,8 @@ class ExperimentLogic(QObject):
 
     def addExperimentDataFromXye(self, file_url):
         self._experiment_data = self._loadExperimentData(file_url)
-        self.state._data.experiments[0].name = pathlib.Path(file_url).stem
-        self.experiments = [{'name': experiment.name} for experiment in self.state._data.experiments]
+        self.parent.setExperimentName(pathlib.Path(file_url).stem)
+        self.experiments = [{'name': experiment.name} for experiment in self.parent.pdata().experiments]
         self.experimentLoaded(True)
         self.experimentSkipped(False)
 
@@ -243,14 +243,11 @@ class ExperimentLogic(QObject):
         # Get background
         background_2thetas = np.fromiter(block.find_loop("_pd_background_2theta"), float)
         background_intensities = np.fromiter(block.find_loop("_pd_background_intensity"), float)
-        self.parent.l_background.addPoints(background_2thetas, background_intensities)
-        self.parent.l_background._setAsXml()
-        self.parent.l_plotting1d.bokehBackgroundDataObjChanged.emit()
+        self.parent.setBackgroundPoints(background_2thetas, background_intensities)
 
     def removeExperiment(self):
-        if len(self.parent.l_sample._sample.pattern.backgrounds) > 0:
-            self.parent.l_background.removeAllPoints()
-        self.parent.l_fitting.removeAllConstraints()
+        self.parent.removeBackgroundPoints()
+        self.parent.removeAllConstraints()
         self.setPolarized(False)
         self._current_spin_component = 'Sum'
         self.experiments.clear()
@@ -259,31 +256,30 @@ class ExperimentLogic(QObject):
         self.experimentSkipped(False)
 
     def _onExperimentSkippedChanged(self):
-        self.state._updateCalculatedData()
+        self.parent.updateCalculatedData()
 
     def _onExperimentLoadedChanged(self):
         self.state._onPatternParametersChanged()
 
     def setCurrentExperimentDatasetName(self, name):
-        self.parent.l_phase.setCurrentExperimentDatasetName(name)
+        self.parent.setCurrentExperimentDatasetName(name)
 
     def initializeBackground(self):
-        self.parent.l_plotting1d.setMeasuredData(
-                                          self._experiment_data.x,
-                                          self._experiment_data.y + self._experiment_data.yb,
-                                          self._experiment_data.e + self._experiment_data.eb)
+        self.parent.setMeasuredData(
+                                    self._experiment_data.x,
+                                    self._experiment_data.y + self._experiment_data.yb,
+                                    self._experiment_data.e + self._experiment_data.eb)
 
-        self.parent.proxy.parameters.simulationParametersAsObj = \
-            json.dumps(self._experiment_parameters)
-        self.parent.l_background.initializeContainer()
+        self.parent.setSimulationParameters(json.dumps(self._experiment_parameters))
+        self.parent.initializeContainer()
 
     def _onExperimentDataAdded(self):
         print("***** _onExperimentDataAdded")
         # default settings are up+down
-        self.parent.l_plotting1d.setMeasuredData(
-                                          self._experiment_data.x,
-                                          self._experiment_data.y + self._experiment_data.yb,
-                                          self._experiment_data.e + self._experiment_data.eb)
+        self.parent.setMeasuredData(
+                                    self._experiment_data.x,
+                                    self._experiment_data.y + self._experiment_data.yb,
+                                    self._experiment_data.e + self._experiment_data.eb)
         self._experiment_parameters = \
             self._experimentDataParameters(self._experiment_data)
 
@@ -291,13 +287,13 @@ class ExperimentLogic(QObject):
         self.parent.proxy.parameters.simulationParametersAsObj = \
             json.dumps(self._experiment_parameters)
 
-        if len(self.parent.l_sample._sample.pattern.backgrounds) == 0:
-            self.parent.l_background.initializeContainer()
+        if len(self.parent.sampleBackgrounds()) == 0:
+            self.parent.initializeContainer()
 
         self.parent.l_project._project_info['experiments'] = \
-            self.parent.l_parameters._data.experiments[0].name
+            self.parent.pdata().experiments[0].name
 
-        self.parent.l_project.projectInfoChanged.emit()
+        self.parent.notifyProjectChanged()
 
     def _onPatternParametersChanged(self):
         self.state._setPatternParametersAsObj()
@@ -331,7 +327,7 @@ class ExperimentLogic(QObject):
         if component is not None:
             self._current_spin_component = component
 
-        phase_label = self.parent.l_phase.phases.phase_names[0]
+        phase_label = self.parent.getPhaseNames()[0]
         components = self._interface.get_phase_components(phase_label)
         calc_y = components['components']['up']
         calc_yb = components['components']['down']
@@ -373,11 +369,11 @@ class ExperimentLogic(QObject):
             sim_x = self._experiment_data.x
         else:
             sim_x = self.state.sim_x()
-        self.parent.l_plotting1d.setBackgroundData(sim_x, bg)
+        self.parent.setBackgroundData(sim_x, bg)
         if has_experiment:
-            self.parent.l_plotting1d.setMeasuredData(self._experiment_data.x, y, e)
+            self.parent.setMeasuredData(self._experiment_data.x, y, e)
 
-        self.parent.l_plotting1d.setCalculatedData(sim_x, sim_y)
+        self.parent.setCalculatedData(sim_x, sim_y)
 
         return has_experiment
 

--- a/easyDiffractionApp/Logic/Experiment.py
+++ b/easyDiffractionApp/Logic/Experiment.py
@@ -29,7 +29,6 @@ class ExperimentLogic(QObject):
     def __init__(self, parent=None, interface=None):
         super().__init__(parent)
         self.parent = parent
-        self.state = parent.l_parameters
         self._interface = interface
         self._experiment_parameters = None
         self._experiment_data_as_xml = ""
@@ -259,7 +258,7 @@ class ExperimentLogic(QObject):
         self.parent.updateCalculatedData()
 
     def _onExperimentLoadedChanged(self):
-        self.state._onPatternParametersChanged()
+        self.parent.onPatternParametersChanged()
 
     def setCurrentExperimentDatasetName(self, name):
         self.parent.setCurrentExperimentDatasetName(name)
@@ -290,17 +289,15 @@ class ExperimentLogic(QObject):
         if len(self.parent.sampleBackgrounds()) == 0:
             self.parent.initializeContainer()
 
-        self.parent.l_project._project_info['experiments'] = \
-            self.parent.pdata().experiments[0].name
-
+        self.parent.setExperimentNameFromParameters()
         self.parent.notifyProjectChanged()
 
     def _onPatternParametersChanged(self):
-        self.state._setPatternParametersAsObj()
+        self.parent.setPatternParametersAsObj()
         self.patternParametersAsObjChanged.emit()
 
     def onClearFrontendState(self):
-        self.parent.l_plotting1d.clearFrontendState()
+        self.parent.clearFrontendState()
 
     def spinComponent(self):
         return self._current_spin_component
@@ -368,7 +365,7 @@ class ExperimentLogic(QObject):
         if has_experiment:
             sim_x = self._experiment_data.x
         else:
-            sim_x = self.state.sim_x()
+            sim_x = self.parent.sim_x()
         self.parent.setBackgroundData(sim_x, bg)
         if has_experiment:
             self.parent.setMeasuredData(self._experiment_data.x, y, e)

--- a/easyDiffractionApp/Logic/Experiment.py
+++ b/easyDiffractionApp/Logic/Experiment.py
@@ -229,7 +229,7 @@ class ExperimentLogic(QObject):
         self.experiments = [{'name': experiment.name} for experiment in self.parent.pdata().experiments]
         self.experimentLoaded(True)
         self.experimentSkipped(False)
-        # need to update parameters in all the places.
+        # slot in Exp proxy -> notify parameter proxy
         self.structureParametersChanged.emit()
 
     def addExperimentDataFromXye(self, file_url):
@@ -298,6 +298,7 @@ class ExperimentLogic(QObject):
 
     def _onPatternParametersChanged(self):
         self.parent.setPatternParametersAsObj()
+        # slot in Exp proxy -> notify Param proxy
         self.patternParametersAsObjChanged.emit()
 
     def onClearFrontendState(self):

--- a/easyDiffractionApp/Logic/Experiment.py
+++ b/easyDiffractionApp/Logic/Experiment.py
@@ -247,12 +247,12 @@ class ExperimentLogic(QObject):
     def removeExperiment(self):
         self.parent.removeBackgroundPoints()
         self.parent.removeAllConstraints()
-        self.setPolarized(False)
         self._current_spin_component = 'Sum'
         self.experiments.clear()
         self._experiment_data = None
         self.experimentLoaded(False)
         self.experimentSkipped(False)
+        self.setPolarized(False)
         self.parent.clearFrontendState()
 
     def _onExperimentSkippedChanged(self):

--- a/easyDiffractionApp/Logic/Fitting.py
+++ b/easyDiffractionApp/Logic/Fitting.py
@@ -185,7 +185,6 @@ class FittingLogic(QObject):
         self.setFailedFitResults()
         self.finishFit()
 
-    # def fit(self, data):
     def fit(self):
         self.data = self.parent.pdata()
         if not self.fit_thread.is_alive():
@@ -202,7 +201,6 @@ class FittingLogic(QObject):
             return
         new_name = self.fitter.available_engines[new_index]
         self.fitter.switch_engine(new_name)
-        self.currentMinimizerChanged.emit()
 
     def onCurrentMinimizerChanged(self):
         idx = 0
@@ -215,7 +213,6 @@ class FittingLogic(QObject):
             # Bypass the property as it would be added to the stack.
             self._current_minimizer_method_index = idx
             self._current_minimizer_method_name = self.minimizerMethodNames()[idx]  # noqa: E501
-            self.currentMinimizerMethodChanged.emit()
         return
 
     def minimizerMethodNames(self):
@@ -233,7 +230,6 @@ class FittingLogic(QObject):
 
         self._current_minimizer_method_index = new_index
         self._current_minimizer_method_name = self.minimizerMethodNames()[new_index]  # noqa: E501
-        self.currentMinimizerMethodChanged.emit()
 
     def setNewEngine(self, engine=None, method=None):
         new_engine_index = self.fitter.available_engines.index(engine)
@@ -269,7 +265,6 @@ class FittingLogic(QObject):
         self.fitter = CoreFitter(self.parent.sample(), self.interface.fit_func)
 
         self.parent.sample().update_bindings()
-        self.currentCalculatorChanged.emit()
         print("***** _onCurrentCalculatorChanged")
         data = self.parent.pdata().simulations[0]
         data.name = f'{self.interface.current_interface_name} engine'

--- a/easyDiffractionApp/Logic/Fitting.py
+++ b/easyDiffractionApp/Logic/Fitting.py
@@ -235,6 +235,12 @@ class FittingLogic(QObject):
         self._current_minimizer_method_name = self.minimizerMethodNames()[new_index]  # noqa: E501
         self.currentMinimizerMethodChanged.emit()
 
+    def setNewEngine(self, engine=None, method=None):
+        new_engine_index = self.fitter.available_engines.index(engine)
+        self.setCurrentMinimizerIndex(new_engine_index)
+        new_method_index = self.minimizerMethodNames().index(method)
+        self.currentMinimizerMethodIndex(new_method_index)
+
     ####################################################################################################################
     # Calculator
     ####################################################################################################################

--- a/easyDiffractionApp/Logic/Fitting.py
+++ b/easyDiffractionApp/Logic/Fitting.py
@@ -43,7 +43,7 @@ class FittingLogic(QObject):
 
         self.parent = parent
         self.interface = interface
-        self.fitter = CoreFitter(self.parent.sample, self.interface.fit_func)
+        self.fitter = CoreFitter(self.parent.sample(), self.interface.fit_func)
 
         # Multithreading
         # self._fitter_thread = None
@@ -271,13 +271,9 @@ class FittingLogic(QObject):
         self.parent.sample().update_bindings()
         self.currentCalculatorChanged.emit()
         print("***** _onCurrentCalculatorChanged")
-        self._onCurrentCalculatorChanged()
-        self.parent.updateCalculatedData()
-
-    def _onCurrentCalculatorChanged(self):
-        data = self.parent.pdata().simulations
-        data = data[0]
+        data = self.parent.pdata().simulations[0]
         data.name = f'{self.interface.current_interface_name} engine'
+        self.parent.updateCalculatedData()
 
     # Constraints
     def addConstraint(self, dependent_par_idx, relational_operator,

--- a/easyDiffractionApp/Logic/LogicController.py
+++ b/easyDiffractionApp/Logic/LogicController.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # © 2021-2022 Contributors to the easyDiffraction project <https://github.com/easyScience/easyDiffractionApp>
 
-import json
 import numpy as np
 
 from PySide2.QtCore import QObject, Signal
@@ -22,6 +21,9 @@ from easyDiffractionLib.interface import InterfaceFactory
 
 
 class LogicController(QObject):
+    """
+    Controller class for communication between the logic components.
+    """
     parametersChanged = Signal()
 
     def __init__(self, parent):
@@ -115,6 +117,9 @@ class LogicController(QObject):
     def plotCalculatedData(self, data):
         self.l_plotting1d.setCalculatedData(data[0], data[1])
 
+    def calculatorListChanged(self):
+        self.proxy.fitting.calculatorListChanged.emit()
+
     def plotBraggData(self, data):
         self.l_plotting1d.setBraggData(data[0], data[1], data[2], data[3], data[4])  # noqa: E501
 
@@ -174,8 +179,8 @@ class LogicController(QObject):
             self.l_experiment.setSpinComponent()
 
     def setExperimentLoaded(self, loaded=True):
-            self.l_experiment.experimentLoaded(loaded)
-            self.l_experiment.experimentSkipped(not loaded)
+        self.l_experiment.experimentLoaded(loaded)
+        self.l_experiment.experimentSkipped(not loaded)
 
     def removeExperiment(self, skipped=False):
         self.l_experiment.experimentLoaded(False)
@@ -200,7 +205,7 @@ class LogicController(QObject):
         return self.l_experiment.experimentDataAsObj()[0]["name"]
 
     def getSampleAsDict(self):
-        return self.l_sample._sample.as_dict(skip=['interface','calculator'])
+        return self.l_sample._sample.as_dict(skip=['interface', 'calculator'])
 
     def setPhaseScale(self, phase_label, phase_scale):
         self.l_phase.phases[phase_label].scale = phase_scale
@@ -222,9 +227,6 @@ class LogicController(QObject):
 
     def getPhaseNames(self):
         return self.l_phase.phases.phase_names
-
-    def phases(self):
-        return self.l_phase.phases
 
     def onPatternParametersChanged(self):
         self.l_parameters._onPatternParametersChanged()

--- a/easyDiffractionApp/Logic/LogicController.py
+++ b/easyDiffractionApp/Logic/LogicController.py
@@ -98,6 +98,9 @@ class LogicController(QObject):
     def isSpinPolarized(self):
         return self.l_experiment.spin_polarized
 
+    def spinComponent(self):
+        return self.l_experiment.spinComponent()
+
     def setSpinComponent(self):
         self.l_experiment.setSpinComponent()
 
@@ -188,8 +191,20 @@ class LogicController(QObject):
     def setPhaseScale(self, phase_label, phase_scale):
         self.l_phase.phases[phase_label].scale = phase_scale
 
+    def sim_x(self):
+        return self.l_parameters.sim_x()
+
     def getPhaseNames(self):
         return self.l_phase.phases.phase_names
+
+    def phases(self):
+        return self.l_phase.phases
+
+    def onPatternParametersChanged(self):
+        self.l_parameters._onPatternParametersChanged()
+
+    def setPatternParametersAsObj(self):
+        self.l_parameters._setPatternParametersAsObj()
 
     def getExperiments(self):
         return self.l_parameters.getExperiments()
@@ -199,6 +214,10 @@ class LogicController(QObject):
 
     def isExperimentSkipped(self):
         return self.l_experiment._experiment_skipped
+
+    def setExperimentNameFromParameters(self):
+        self.l_project._project_info['experiments'] = \
+            self.l_parameters._data.experiments[0].name
 
     def fittingNamesDict(self):
         return self.l_fitting.fittingNamesDict()
@@ -234,6 +253,9 @@ class LogicController(QObject):
 
     def setCalculatedData(self, x, y):
         self.l_plotting1d.setCalculatedData(x, y)
+
+    def clearFrontendState(self):
+        self.l_plotting1d.clearFrontendState()
 
     def setBackgroundPoints(self, bg_2thetas, bg_intensities):
         self.l_background.addPoints(bg_2thetas, bg_intensities)

--- a/easyDiffractionApp/Logic/LogicController.py
+++ b/easyDiffractionApp/Logic/LogicController.py
@@ -69,7 +69,6 @@ class LogicController(QObject):
         self.l_project.phasesAsObjChanged.connect(self.l_phase.phasesAsObjChanged)
         # self.l_project.experimentDataAdded.connect(self.l_experiment._onExperimentDataAdded)
         self.l_project.structureParametersChanged.connect(self.l_phase.structureParametersChanged)
-        # self.l_project.experimentLoadedChanged.connect(self.l_experiment.experimentLoadedChanged)
 
         # the following data update is required for undo/redo.
         self.parametersChanged.connect(self.l_parameters._updateCalculatedData)

--- a/easyDiffractionApp/Logic/LogicController.py
+++ b/easyDiffractionApp/Logic/LogicController.py
@@ -122,6 +122,9 @@ class LogicController(QObject):
     def initializeBorg(self):
         self.l_stack.initializeBorg()
 
+    def assignPhaseIndex(self):
+        self.sample().output_index = self.l_phase._current_phase_index
+
     def resetState(self):
         self.l_fitting.setCurrentCalculatorIndex(0)
         if self.l_phase.samplesPresent():
@@ -160,6 +163,9 @@ class LogicController(QObject):
             self.l_parameters._data.experiments[0].eb = np.zeros(length)
             self.l_experiment.spin_polarized = False
 
+    def fnAggregate(self):
+        return self.l_experiment.fn_aggregate
+
     def sampleBackgrounds(self):
         return self.l_sample._sample.pattern.backgrounds
 
@@ -185,17 +191,32 @@ class LogicController(QObject):
     def experimentType(self):
         return self.l_sample.experimentType
 
+    def experimentLoaded(self):
+        return self.l_experiment._experiment_loaded
+
+    def experimentSkipped(self):
+        return self.l_experiment._experiment_skipped
+
+    def experimentName(self):
+        return self.l_experiment.experimentDataAsObj()[0]["name"]
+
     def getSampleAsDict(self):
         return self.l_sample._sample.as_dict(skip=['interface','calculator'])
 
     def setPhaseScale(self, phase_label, phase_scale):
         self.l_phase.phases[phase_label].scale = phase_scale
 
+    def setCalculatedDataForPhase(self):
+        self.l_plotting1d.setCalculatedDataForPhase()
+
     def phases(self):
         return self.l_phase.phases
 
     def phasesAsObjChanged(self):
         self.l_phase.phasesAsObjChanged.emit()
+
+    def setPhasesOnSample(self, phases):
+        self.l_sample._sample.phases = phases
 
     def sim_x(self):
         return self.l_parameters.sim_x()
@@ -208,6 +229,9 @@ class LogicController(QObject):
 
     def onPatternParametersChanged(self):
         self.l_parameters._onPatternParametersChanged()
+
+    def emitParametersChanged(self):
+        self.l_parameters.parametersChanged.emit()
 
     def setPatternParametersAsObj(self):
         self.l_parameters._setPatternParametersAsObj()

--- a/easyDiffractionApp/Logic/LogicController.py
+++ b/easyDiffractionApp/Logic/LogicController.py
@@ -89,6 +89,24 @@ class LogicController(QObject):
     def resetFactory(self):
         self.interface = InterfaceFactory()
 
+    def sample(self):
+        return self.l_sample._sample
+
+    def refinementMethods(self):
+        return self.l_experiment.refinement_methods()
+
+    def isSpinPolarized(self):
+        return self.l_experiment.spin_polarized
+
+    def setSpinComponent(self):
+        self.l_experiment.setSpinComponent()
+
+    def pdata(self):
+        return self.l_parameters._data
+
+    def updateCalculatedData(self):
+        self.l_parameters._updateCalculatedData()
+
     def plotCalculatedData(self, data):
         self.l_plotting1d.setCalculatedData(data[0], data[1])
 
@@ -115,10 +133,9 @@ class LogicController(QObject):
         self.l_phase.phaseAdded.emit()
 
     def sendToExperiment(self, data, exp_name):
-
         self.setExperimentLoaded(True)
         self.setExperimentData(data)
-        self.updateExperimentData(exp_name)
+        self.l_experiment.updateExperimentData(exp_name)
         self.updateBackgroundOnLoad()
         self.l_experiment.experimentLoadedChanged.emit()
 
@@ -137,9 +154,6 @@ class LogicController(QObject):
             self.l_parameters._data.experiments[0].eb = np.zeros(length)
             self.l_experiment.spin_polarized = False
 
-    def updateExperimentData(self, name=None):
-        self.l_experiment.updateExperimentData(name=name)
-
     def updateBackgroundOnLoad(self):
             self.l_background.onAsObjChanged()
             if self.l_experiment.spin_polarized:
@@ -155,6 +169,18 @@ class LogicController(QObject):
         if skipped:
             self.l_experiment.experimentSkipped(True)
             self.l_experiment.experimentSkippedChanged.emit()
+
+    def getSampleAsDict(self):
+        return self.l_sample._sample.as_dict(skip=['interface','calculator'])
+
+    def getExperiments(self):
+        return self.l_parameters.getExperiments()
+
+    def isExperimentSkipped(self):
+        return self.l_experiment._experiment_skipped
+
+    def fittingNamesDict(self):
+        return self.l_fitting.fittingNamesDict()
 
     def resetStack(self):
         self.l_stack.resetUndoRedoStack()

--- a/easyDiffractionApp/Logic/LogicController.py
+++ b/easyDiffractionApp/Logic/LogicController.py
@@ -104,6 +104,9 @@ class LogicController(QObject):
     def pdata(self):
         return self.l_parameters._data
 
+    def setExperimentName(self, name=""):
+        self.l_parameters._data.experiments[0].name = name
+
     def updateCalculatedData(self):
         self.l_parameters._updateCalculatedData()
 
@@ -154,10 +157,13 @@ class LogicController(QObject):
             self.l_parameters._data.experiments[0].eb = np.zeros(length)
             self.l_experiment.spin_polarized = False
 
+    def sampleBackgrounds(self):
+        return self.l_sample._sample.pattern.backgrounds
+
     def updateBackgroundOnLoad(self):
-            self.l_background.onAsObjChanged()
-            if self.l_experiment.spin_polarized:
-                self.l_experiment.setSpinComponent()
+        self.l_background.onAsObjChanged()
+        if self.l_experiment.spin_polarized:
+            self.l_experiment.setSpinComponent()
 
     def setExperimentLoaded(self, loaded=True):
             self.l_experiment.experimentLoaded(loaded)
@@ -170,11 +176,26 @@ class LogicController(QObject):
             self.l_experiment.experimentSkipped(True)
             self.l_experiment.experimentSkippedChanged.emit()
 
+    def setExperimentType(self, type=""):
+        self.l_sample.experimentType = type
+
+    def experimentType(self):
+        return self.l_sample.experimentType
+
     def getSampleAsDict(self):
         return self.l_sample._sample.as_dict(skip=['interface','calculator'])
 
+    def setPhaseScale(self, phase_label, phase_scale):
+        self.l_phase.phases[phase_label].scale = phase_scale
+
+    def getPhaseNames(self):
+        return self.l_phase.phases.phase_names
+
     def getExperiments(self):
         return self.l_parameters.getExperiments()
+
+    def setCurrentExperimentDatasetName(self, name):
+        self.l_phase.setCurrentExperimentDatasetName(name)
 
     def isExperimentSkipped(self):
         return self.l_experiment._experiment_skipped
@@ -201,6 +222,36 @@ class LogicController(QObject):
         engine_name = self.l_fitting.fitter.current_engine.name
         minimizer_name = self.l_fitting._current_minimizer_method_name
         return self.l_state.statusModelAsXml(engine_name, minimizer_name)
+
+    def initializeContainer(self):
+        self.l_background.initializeContainer()
+
+    def setBackgroundData(self, x, y):
+        self.l_plotting1d.setBackgroundData(x, y)
+
+    def setMeasuredData(self, x, y, e):
+        self.l_plotting1d.setMeasuredData(x, y, e)
+
+    def setCalculatedData(self, x, y):
+        self.l_plotting1d.setCalculatedData(x, y)
+
+    def setBackgroundPoints(self, bg_2thetas, bg_intensities):
+        self.l_background.addPoints(bg_2thetas, bg_intensities)
+        self.l_background._setAsXml()
+        self.l_plotting1d.bokehBackgroundDataObjChanged.emit()
+
+    def removeBackgroundPoints(self):
+        if len(self.l_sample._sample.pattern.backgrounds) > 0:
+            self.l_background.removeAllPoints()
+
+    def removeAllConstraints(self):
+        self.l_fitting.removeAllConstraints()
+
+    def setSimulationParameters(self, params):
+        self.proxy.parameters.simulationParametersAsObj = params
+
+    def notifyProjectChanged(self):
+        self.l_project.projectInfoChanged.emit()
 
     def recorder(self):
         rec = None

--- a/easyDiffractionApp/Logic/LogicController.py
+++ b/easyDiffractionApp/Logic/LogicController.py
@@ -191,6 +191,12 @@ class LogicController(QObject):
     def setPhaseScale(self, phase_label, phase_scale):
         self.l_phase.phases[phase_label].scale = phase_scale
 
+    def phases(self):
+        return self.l_phase.phases
+
+    def phasesAsObjChanged(self):
+        self.l_phase.phasesAsObjChanged.emit()
+
     def sim_x(self):
         return self.l_parameters.sim_x()
 

--- a/easyDiffractionApp/Logic/LogicController.py
+++ b/easyDiffractionApp/Logic/LogicController.py
@@ -65,11 +65,9 @@ class LogicController(QObject):
 
         self.l_fitting.fitFinished.connect(self.parametersChanged)
         self.l_fitting.fitFinished.connect(self.l_parameters.parametersChanged)
-        self.l_fitting.currentCalculatorChanged.connect(self.proxy.currentCalculatorChanged)
 
         self.l_project.phasesEnabled.connect(self.l_phase.phasesEnabled)
         self.l_project.phasesAsObjChanged.connect(self.l_phase.phasesAsObjChanged)
-        # self.l_project.experimentDataAdded.connect(self.l_experiment._onExperimentDataAdded)
         self.l_project.structureParametersChanged.connect(self.l_phase.structureParametersChanged)
 
         # the following data update is required for undo/redo.
@@ -107,6 +105,9 @@ class LogicController(QObject):
 
     def pdata(self):
         return self.l_parameters._data
+
+    def experiments(self):
+        return self.pdata().experiments
 
     def setExperimentName(self, name=""):
         self.l_parameters._data.experiments[0].name = name
@@ -189,8 +190,8 @@ class LogicController(QObject):
             self.l_experiment.experimentSkipped(True)
             self.l_experiment.experimentSkippedChanged.emit()
 
-    def setExperimentType(self, type=""):
-        self.l_sample.experimentType = type
+    def setExperimentType(self, t=""):
+        self.l_sample.experimentType = t
 
     def experimentType(self):
         return self.l_sample.experimentType

--- a/easyDiffractionApp/Logic/Parameters.py
+++ b/easyDiffractionApp/Logic/Parameters.py
@@ -327,6 +327,19 @@ class ParametersLogic(QObject):
         obj = borg.map.get_item_by_key(obj_id)
         return obj
 
+    def getExperiments(self):
+        experiments = []
+        if self._data.experiments:
+            experiments_x = self._data.experiments[0].x
+            experiments_y = self._data.experiments[0].y
+            experiments_e = self._data.experiments[0].e
+            experiments = [experiments_x, experiments_y, experiments_e]
+            if self.parent.isSpinPolarized():
+                experiments_yb = self._data.experiments[0].yb
+                experiments_eb = self._data.experiments[0].eb
+                experiments += [experiments_yb, experiments_eb]
+        return experiments
+
     def sim_x(self):
         """
         Rerurn the x-axis of the simulated data.

--- a/easyDiffractionApp/Logic/Parameters.py
+++ b/easyDiffractionApp/Logic/Parameters.py
@@ -119,7 +119,7 @@ class ParametersLogic(QObject):
         }
 
     def _setPatternParametersAsObj(self):
-        parameters = self.parent.l_sample._sample.pattern.as_dict(skip=['interface'])
+        parameters = self.parent.sample().pattern.as_dict(skip=['interface'])
         self._pattern_parameters_as_obj = parameters
 
     ####################################################################################################################
@@ -138,7 +138,7 @@ class ParametersLogic(QObject):
 
     def _setInstrumentParametersAsObj(self):
         # parameters = self._sample.parameters.as_dict()
-        parameters = self.parent.l_sample._sample.parameters.as_dict(skip=['interface'])
+        parameters = self.parent.sample().parameters.as_dict(skip=['interface'])
         self._instrument_parameters_as_obj = parameters
 
     def _setInstrumentParametersAsXml(self):
@@ -233,7 +233,7 @@ class ParametersLogic(QObject):
     def _setParametersAsObj(self):
         self._parameters_as_obj.clear()
 
-        par_ids, par_paths = generatePath(self.parent.l_sample._sample, True)
+        par_ids, par_paths = generatePath(self.parent.sample(), True)
         par_index = 0
 
         for par_id, par_path in zip(par_ids, par_paths):
@@ -244,11 +244,12 @@ class ParametersLogic(QObject):
                 continue
 
             # rename some groups of parameters and add experimental dataset name
-            par_path = par_path.replace('Instrument1DCWPolParameters.', f'Instrument.{self.parent.l_experiment.experimentDataAsObj()[0]["name"]}.')
-            par_path = par_path.replace('Instrument1DCWParameters.', f'Instrument.{self.parent.l_experiment.experimentDataAsObj()[0]["name"]}.')
-            par_path = par_path.replace('Instrument1DTOFParameters.', f'Instrument.{self.parent.l_experiment.experimentDataAsObj()[0]["name"]}.')
-            par_path = par_path.replace('PolPowder1DParameters.', f'Instrument.{self.parent.l_experiment.experimentDataAsObj()[0]["name"]}.')
-            par_path = par_path.replace('Powder1DParameters.', f'Instrument.{self.parent.l_experiment.experimentDataAsObj()[0]["name"]}.')
+            exp_name = self.parent.experimentName()
+            par_path = par_path.replace('Instrument1DCWPolParameters.', f'Instrument.{exp_name}.')
+            par_path = par_path.replace('Instrument1DCWParameters.', f'Instrument.{exp_name}.')
+            par_path = par_path.replace('Instrument1DTOFParameters.', f'Instrument.{exp_name}.')
+            par_path = par_path.replace('PolPowder1DParameters.', f'Instrument.{exp_name}.')
+            par_path = par_path.replace('Powder1DParameters.', f'Instrument.{exp_name}.')
             par_path = par_path.replace('.sigma0', '.resolution_sigma0')
             par_path = par_path.replace('.sigma1', '.resolution_sigma1')
             par_path = par_path.replace('.sigma2', '.resolution_sigma2')
@@ -357,35 +358,35 @@ class ParametersLogic(QObject):
     # Calculated data
     ####################################################################################################################
     def _updateCalculatedData(self):
-        if not self.parent.l_experiment._experiment_loaded and not self.parent.l_experiment._experiment_skipped:
+        if not self.parent.experimentLoaded() and not self.parent.experimentSkipped():
             return
 
-        self.parent.l_sample._sample.output_index = self.parent.l_phase._current_phase_index
+        self.parent.assignPhaseIndex()
 
         #  THIS IS WHERE WE WOULD LOOK UP CURRENT EXP INDEX
         sim = self._data.simulations[0]
 
-        if self.parent.l_experiment._experiment_loaded:
+        if self.parent.experimentLoaded():
             exp = self._data.experiments[0]
             sim.x = exp.x
 
-        elif self.parent.l_experiment._experiment_skipped:
+        elif self.parent.experimentSkipped():
             sim.x = self.sim_x()
 
         kwargs = {}
-        if self.parent.l_experiment.spin_polarized:
-            fn = self.parent.l_experiment.fn_aggregate
+        if self.parent.isSpinPolarized():
+            fn = self.parent.fnAggregate()
             kwargs["pol_fn"] = fn
             # save some kwargs on the interface object for use in the calculator
             # self._interface._InterfaceFactoryTemplate__interface_obj.saved_kwargs = local_kwargs
 
         sim.y = self._interface.fit_func(sim.x, **kwargs)
-        if self.parent.l_experiment.spin_polarized:
-            self.parent.l_experiment.setSpinComponent()
+        if self.parent.isSpinPolarized():
+            self.parent.setSpinComponent()
         else:
             self.plotCalculatedDataSignal.emit((sim.x, sim.y))
 
-        for phase_index, phase_name in enumerate([str(phase._borg.map.convert_id(phase).int) for phase in self.parent.l_phase.phases]):
+        for phase_index, phase_name in enumerate([str(phase._borg.map.convert_id(phase).int) for phase in self.parent.phases()]):
             hkl = self._interface.get_hkl(x_array=sim.x, phase_name=phase_name, encoded_name=True)
             if 'ttheta' in hkl.keys():
                 self.plotBraggDataSignal.emit((phase_index, hkl['ttheta'], hkl['h'], hkl['k'], hkl['l']))  # noqa: E501

--- a/easyDiffractionApp/Logic/Phase.py
+++ b/easyDiffractionApp/Logic/Phase.py
@@ -248,7 +248,7 @@ class PhaseLogic(QObject):
         self.updateParameters()
 
     def setCurrentExperimentDatasetName(self, name):
-        if self.parent.pdata().experiments[0].name == name:
+        if self.parent.experiments()[0].name == name:
             return
         self.parent.setExperimentName(name)
         self.updateProjectInfo.emit(('experiments', name))

--- a/easyDiffractionApp/Logic/Phase.py
+++ b/easyDiffractionApp/Logic/Phase.py
@@ -31,7 +31,6 @@ class PhaseLogic(QObject):
         super().__init__(parent)
         self.parent = parent
         self._interface = interface
-        self.state = parent.l_parameters
         self.phases = Phases()
         self._phases_as_obj = []
         self._phases_as_xml = ""
@@ -123,14 +122,14 @@ class PhaseLogic(QObject):
         if self._phases_as_cif == phases_as_cif:
             return
         self.phases = Phases.from_cif_str(phases_as_cif)
-        self.parent.l_sample._sample.phases = self.phases
+        self.parent.setPhasesOnSample(self.phases)
         self.updateParameters()
 
     def _setPhasesAsObj(self):
         self._phases_as_obj = self.phases.as_dict(skip=['interface'])['data']
-        self.parent.l_plotting1d.setCalculatedDataForPhase()
+        self.parent.setCalculatedDataForPhase()
         # phase set - update xml so parameter table is also updated
-        self.parent.l_parameters.parametersChanged.emit()
+        self.parent.emitParametersChanged()
 
     def _setPhasesAsXml(self):
         self._phases_as_xml = dicttoxml(self._phases_as_obj, attr_type=True).decode()  # noqa: E501
@@ -147,7 +146,7 @@ class PhaseLogic(QObject):
 
     def updateParameters(self):
         self.parent.parametersChanged.emit()
-        self.parent.l_parameters.parametersChanged.emit()
+        self.parent.emitParametersChanged()
 
     def _spaceGroupSettingList(self):
         phases = self.phases
@@ -249,9 +248,9 @@ class PhaseLogic(QObject):
         self.updateParameters()
 
     def setCurrentExperimentDatasetName(self, name):
-        if self.parent.l_parameters._data.experiments[0].name == name:
+        if self.parent.pdata().experiments[0].name == name:
             return
-        self.parent.l_parameters._data.experiments[0].name = name
+        self.parent.setExperimentName(name)
         self.updateProjectInfo.emit(('experiments', name))
 
     def addSampleFromCif(self, cif_url):
@@ -288,4 +287,4 @@ class PhaseLogic(QObject):
         return result
 
     def _updateCalculatedData(self):
-        self.state._updateCalculatedData()
+        self.parent.updateCalculatedData()

--- a/easyDiffractionApp/Logic/Phase.py
+++ b/easyDiffractionApp/Logic/Phase.py
@@ -23,7 +23,7 @@ class PhaseLogic(QObject):
     phaseAdded = Signal()
     updateProjectInfo = Signal(tuple)
     structureParametersChanged = Signal()
-    phasesEnabled = Signal()  # from other logics
+    phasesEnabled = Signal()
     phasesAsObjChanged = Signal()
     phasesReplaced = Signal()
 

--- a/easyDiffractionApp/Logic/Plotting1d.py
+++ b/easyDiffractionApp/Logic/Plotting1d.py
@@ -305,15 +305,15 @@ class Plotting1dLogic(QObject):
         self.bokehMeasuredDataObjChanged.emit()
 
     def _setBokehPhasesDataObj(self):
-        for phase_index in range(len(self.parent.l_phase.phases)):
+        for phase_index in range(len(self.parent.phases())):
             # skip this step with try-except block until instrumental parameters are defined/loaded
             try:
-                if not self.parent.l_experiment.spin_polarized:
+                if not self.parent.isSpinPolarized():
                     yarray = self._interface.get_calculated_y_for_phase(phase_index)
                     is_diff = False
                 else:
                     phases_y = list(self._interface.get_component('phases').values())[phase_index]
-                    component = self.parent.l_experiment.spinComponent()
+                    component = self.parent.spinComponent()
                     is_diff = False
                     if component == "Sum":
                         yarray = phases_y["components"]["up"] + phases_y["components"]["down"]

--- a/easyDiffractionApp/Logic/Plotting1d.py
+++ b/easyDiffractionApp/Logic/Plotting1d.py
@@ -42,7 +42,6 @@ class Plotting1dLogic(QObject):
         # Lib
         self._libs = ['bokeh', 'qtcharts']
         self._current_lib = 'bokeh'
-        self.currentLibChanged.connect(self.onCurrentLibChanged)
 
         # Ranges
         self._measured_min_x = 999999
@@ -102,6 +101,7 @@ class Plotting1dLogic(QObject):
         if self._current_lib == lib:
             return
         self._current_lib = lib
+        self.onCurrentLibChanged()
         self.currentLibChanged.emit()
 
     def clearBackendState(self):

--- a/easyDiffractionApp/Logic/Project.py
+++ b/easyDiffractionApp/Logic/Project.py
@@ -227,28 +227,18 @@ class ProjectLogic(QObject):
         projectPath = self._currentProjectPath
         project_save_filepath = os.path.join(projectPath, 'project.json')
         descr = {
-            'sample': self.parent.l_sample._sample.as_dict(skip=['interface','calculator'])
+            'sample': self.parent.getSampleAsDict()
         }
-        if self.parent.l_parameters._data.experiments:
-            experiments_x = self.parent.l_parameters._data.experiments[0].x
-            experiments_y = self.parent.l_parameters._data.experiments[0].y
-            experiments_e = self.parent.l_parameters._data.experiments[0].e
-            descr['experiments'] = [experiments_x, experiments_y, experiments_e]
-            if self.parent.l_experiment.spin_polarized:
-                experiments_yb = self.parent.l_parameters._data.experiments[0].yb
-                experiments_eb = self.parent.l_parameters._data.experiments[0].eb
-                descr['experiments'] += [experiments_yb, experiments_eb]
+        descr['experiments'] = self.parent.getExperiments()
 
-        descr['experiment_skipped'] = self.parent.l_experiment._experiment_skipped
+        descr['experiment_skipped'] = self.parent.isExperimentSkipped()
         descr['read_only'] = self._read_only
         descr['project_info'] = self._project_info
 
         descr['interface'] = self._interface.current_interface_name
 
-        descr['minimizer'] = {
-            'engine': self.parent.l_fitting.fitter.current_engine.name,
-            'method': self.parent.l_fitting._current_minimizer_method_name
-        }
+        descr['minimizer'] = self.parent.fittingNamesDict()
+
         content_json = json.dumps(descr, indent=4, default=self.default)
         path = generalizePath(project_save_filepath)
         createFile(path, content_json)

--- a/easyDiffractionApp/Logic/Project.py
+++ b/easyDiffractionApp/Logic/Project.py
@@ -257,7 +257,6 @@ class ProjectLogic(QObject):
         self.setProjectCreated(False)
         self.projectInfoChanged.emit()
         self.project_save_filepath = ""
-        self.removeExperiment.emit()
         self.parent.resetState()
 
     def updateProjectInfo(self, key_value):

--- a/easyDiffractionApp/Logic/Project.py
+++ b/easyDiffractionApp/Logic/Project.py
@@ -24,7 +24,6 @@ class ProjectLogic(QObject):
     projectCreatedChanged = Signal()
     projectInfoChanged = Signal()
     reset = Signal()
-    phasesEnabled = Signal()
     phasesAsObjChanged = Signal()
     structureParametersChanged = Signal()
     experimentDataAdded = Signal()

--- a/easyDiffractionApp/Logic/Project.py
+++ b/easyDiffractionApp/Logic/Project.py
@@ -27,7 +27,6 @@ class ProjectLogic(QObject):
     phasesAsObjChanged = Signal()
     structureParametersChanged = Signal()
     experimentDataAdded = Signal()
-    removeExperiment = Signal()
     experimentLoadedChanged = Signal()
 
     def __init__(self, parent=None , interface=None):
@@ -263,6 +262,11 @@ class ProjectLogic(QObject):
             self._project_info[key_value[0]] = key_value[1]
             self.projectInfoChanged.emit()
 
+    def statusModelAsObj(self):
+        return self.parent.statusModelAsObj()
+
+    def statusModelAsXml(self):
+        return self.parent.statusModelAsXml()
 
 def createFile(path, content):
     if os.path.exists(path):

--- a/easyDiffractionApp/Logic/Project.py
+++ b/easyDiffractionApp/Logic/Project.py
@@ -187,13 +187,9 @@ class ProjectLogic(QObject):
                 self._interface.switch(interface_name)
 
         descr['sample']['interface'] = self._interface
-        self.parent.l_sample._sample = Sample.from_dict(descr['sample'])
+        sample_descr = Sample.from_dict(descr['sample'])
 
-        self.parent.l_phase.phases = self.parent.l_sample._sample._phases
-        self.parent.proxy.sample.updateExperimentType()
-
-        # send signal to tell the proxy we changed phases
-        self.parent.l_phase.phaseAdded.emit()
+        self.parent.assignToSample(sample_descr)
 
         # project info
         self._project_info = descr['project_info']
@@ -203,52 +199,25 @@ class ProjectLogic(QObject):
 
         # experiment
         if 'experiments' in descr:
-            self.parent.l_experiment.experimentLoaded(True)
-            self.parent.l_experiment.experimentSkipped(False)
-            self.parent.l_parameters._data.experiments[0].x = np.array(descr['experiments'][0])
-            self.parent.l_parameters._data.experiments[0].y = np.array(descr['experiments'][1])
-            self.parent.l_parameters._data.experiments[0].e = np.array(descr['experiments'][2])
-            if(len(descr['experiments']) > 3):
-                self.parent.l_parameters._data.experiments[0].yb = np.array(descr['experiments'][3])
-                self.parent.l_parameters._data.experiments[0].eb = np.array(descr['experiments'][4])
-                self.parent.l_experiment.spin_polarized = True
-            else:
-                length = len(self.parent.l_parameters._data.experiments[0].y)
-                self.parent.l_parameters._data.experiments[0].yb = np.zeros(length)
-                self.parent.l_parameters._data.experiments[0].eb = np.zeros(length)
-                self.parent.l_experiment.spin_polarized = False
-            self.parent.l_experiment._experiment_data = self.parent.l_parameters._data.experiments[0]
-            self.parent.l_experiment.experiments = [{'name': descr['project_info']['experiments']}]
-            self.parent.l_experiment.setCurrentExperimentDatasetName(descr['project_info']['experiments'])
-            self.parent.l_experiment.setPolarized(self.parent.l_experiment.spin_polarized)
-            # send signal to tell the proxy we changed experiment
-            self.experimentDataAdded.emit()
-            self.parent.l_background.onAsObjChanged()
-            if self.parent.l_experiment.spin_polarized:
-                self.parent.l_experiment.setSpinComponent()
-            self.experimentLoadedChanged.emit()
+            data = descr['experiments']
+            exp_name = descr['project_info']['experiments']
+
+            self.parent.sendToExperiment(data, exp_name)
         else:
             # delete existing experiment
-            self.parent.l_experiment.removeExperiment()
-            self.parent.l_experiment.experimentLoaded(False)
-            if descr['experiment_skipped']:
-                self.parent.l_experiment.experimentSkipped(True)
-                self.parent.l_experiment.experimentSkippedChanged.emit()
-
+            self.parent.removeExperiment(skipped=descr['experiment_skipped'])
 
         new_minimizer_settings = descr.get('minimizer', None)
         if new_minimizer_settings is not None:
             new_engine = new_minimizer_settings['engine']
             new_method = new_minimizer_settings['method']
+            self.parent.setNewEngine(engine=new_engine, method=new_method)
 
-            new_engine_index = self.parent.l_fitting.fitter.available_engines.index(new_engine)
-            self.parent.l_fitting.setCurrentMinimizerIndex(new_engine_index)
-            new_method_index = self.parent.l_fitting.minimizerMethodNames().index(new_method)
-            self.parent.l_fitting.currentMinimizerMethodIndex(new_method_index)
+        self.parent.setSampleOnFitter()
 
-        self.parent.l_fitting.fitter.fit_object = self.parent.l_sample._sample
-        self.parent.l_stack.resetUndoRedoStack()
-        self.parent.l_stack.undoRedoChanged.emit()
+        # tell the LC that the stack needs resetting
+        self.parent.resetStack()
+
         self.setProjectCreated(True)
         print("\nProject loading time: {0:.3f} s\n".format(timer() - start_time))
 
@@ -299,10 +268,7 @@ class ProjectLogic(QObject):
         self.projectInfoChanged.emit()
         self.project_save_filepath = ""
         self.removeExperiment.emit()
-        self.parent.l_fitting.setCurrentCalculatorIndex(0)
-        if self.parent.l_phase.samplesPresent():
-            self.parent.l_phase.removeAllPhases()
-        self.reset.emit()
+        self.parent.resetState()
 
     def updateProjectInfo(self, key_value):
         if len(key_value) == 2:

--- a/easyDiffractionApp/Logic/Proxies/Experiment.py
+++ b/easyDiffractionApp/Logic/Proxies/Experiment.py
@@ -24,11 +24,13 @@ class ExperimentProxy(QObject):
         self.logic = logic.l_experiment
         self.logic.experimentLoadedChanged.connect(self.experimentLoadedChanged)
         self.logic.experimentSkippedChanged.connect(self.experimentSkippedChanged)
-        self.logic.experimentDataChanged.connect(self.experimentDataChanged)
         self.experimentDataChanged.connect(self._onExperimentDataChanged)
         self.experimentSkippedChanged.connect(self._onExperimentSkippedChanged)
         self.experimentLoadedChanged.connect(self._onExperimentLoadedChanged)
+
+        # notifiers for other proxies
         self.logic.patternParametersAsObjChanged.connect(self.parent.parameters.patternParametersAsObjChanged)
+        self.logic.structureParametersChanged.connect(self.parent.phase.structureParametersChanged)
 
     @Property('QVariant', notify=experimentDataChanged)
     def experimentDataAsObj(self):
@@ -144,17 +146,12 @@ class ExperimentProxy(QObject):
     def removeExperiment(self):
         print("+ removeExperiment")
         self.logic.removeExperiment()
-        self._onExperimentDataRemoved()
+        self.experimentDataChanged.emit()
         self.experimentLoadedChanged.emit()
 
     def _loadExperimentData(self, file_url):
         print("+ _loadExperimentData")
         return self.logic._loadExperimentData(file_url)
-
-    def _onExperimentDataRemoved(self):
-        print("***** _onExperimentDataRemoved")
-        self.logic.clearFrontendState.emit()
-        self.experimentDataChanged.emit()
 
     @Property(bool, notify=experimentLoadedChanged)
     def experimentLoaded(self):

--- a/easyDiffractionApp/Logic/Proxies/Phase.py
+++ b/easyDiffractionApp/Logic/Proxies/Phase.py
@@ -32,7 +32,6 @@ class PhaseProxy(QObject):
         self.logic.structureParametersChanged.connect(self.structureParametersChanged)
 
         self.logic.phaseAdded.connect(self._onPhaseAdded)
-        self.logic.phaseAdded.connect(self.phasesEnabled)
         self.logic.phasesEnabled.connect(self.phasesEnabled)
         self.logic.phasesAsObjChanged.connect(self.phasesAsObjChanged)
         self.logic.phasesAsObjChanged.connect(self.structureViewChanged)

--- a/easyDiffractionApp/Logic/Proxies/Phase.py
+++ b/easyDiffractionApp/Logic/Proxies/Phase.py
@@ -17,8 +17,6 @@ class PhaseProxy(QObject):
     phasesAsCifChanged = Signal()
     currentPhaseChanged = Signal()
     phasesEnabled = Signal()
-    stateChanged = Signal(bool)
-    projectInfoChanged = Signal()
     structureParametersChanged = Signal()
     structureViewChanged = Signal()
 
@@ -87,7 +85,7 @@ class PhaseProxy(QObject):
         self._setPhasesAsObj()
         self._setPhasesAsXml()
         self._setPhasesAsCif()
-        self.stateChanged.emit(True)
+        self.parent._project_proxy.stateChanged.emit(True)
 
     ####################################################################################################################
     # Phase: Add / Remove
@@ -121,7 +119,7 @@ class PhaseProxy(QObject):
         self.phasesEnabled.emit()
         self.phasesAsObjChanged.emit()
         self.structureParametersChanged.emit()
-        self.projectInfoChanged.emit()
+        self.parent._project_proxy.projectInfoChanged.emit()
 
     @Property(bool, notify=phasesEnabled)
     def samplesPresent(self) -> bool:
@@ -215,4 +213,5 @@ class PhaseProxy(QObject):
             return
         self.logic.setCurrentPhaseName(name)
         self.structureParametersChanged.emit()
-        self.projectInfoChanged.emit()
+        self.parent._project_proxy.projectInfoChanged.emit()
+

--- a/easyDiffractionApp/Logic/Proxies/Phase.py
+++ b/easyDiffractionApp/Logic/Proxies/Phase.py
@@ -17,6 +17,8 @@ class PhaseProxy(QObject):
     phasesAsCifChanged = Signal()
     currentPhaseChanged = Signal()
     phasesEnabled = Signal()
+    stateChanged = Signal(bool)
+    projectInfoChanged = Signal()
     structureParametersChanged = Signal()
     structureViewChanged = Signal()
 
@@ -86,7 +88,7 @@ class PhaseProxy(QObject):
         self._setPhasesAsObj()
         self._setPhasesAsXml()
         self._setPhasesAsCif()
-        self.parent._project_proxy.stateChanged.emit(True)
+        self.stateChanged.emit(True)
 
     ####################################################################################################################
     # Phase: Add / Remove
@@ -120,7 +122,7 @@ class PhaseProxy(QObject):
         self.phasesEnabled.emit()
         self.phasesAsObjChanged.emit()
         self.structureParametersChanged.emit()
-        self.parent._project_proxy.projectInfoChanged.emit()
+        self.projectInfoChanged.emit()
 
     @Property(bool, notify=phasesEnabled)
     def samplesPresent(self) -> bool:
@@ -214,4 +216,4 @@ class PhaseProxy(QObject):
             return
         self.logic.setCurrentPhaseName(name)
         self.structureParametersChanged.emit()
-        self.parent._project_proxy.projectInfoChanged.emit()
+        self.projectInfoChanged.emit()

--- a/easyDiffractionApp/Logic/Proxies/Plotting3d.py
+++ b/easyDiffractionApp/Logic/Proxies/Plotting3d.py
@@ -16,7 +16,6 @@ class Plotting3dProxy(QObject):
 
     def __init__(self, logic=None):
         super().__init__()
-        # self.parent = parent
         self.logic = logic.l_plotting3d
         self.current3dPlottingLibChanged.connect(self.onCurrent3dPlottingLibChanged)
 

--- a/easyDiffractionApp/Logic/Proxies/Project.py
+++ b/easyDiffractionApp/Logic/Proxies/Project.py
@@ -101,6 +101,7 @@ class ProjectProxy(QObject):
     @Slot()
     def resetState(self):
         self.logic.resetState()
+        self.removeExperiment.emit()
         self.logic.stateHasChanged(False)
         self.stateChanged.emit(False)
 

--- a/easyDiffractionApp/Logic/Proxies/Project.py
+++ b/easyDiffractionApp/Logic/Proxies/Project.py
@@ -11,7 +11,7 @@ class ProjectProxy(QObject):
     dummySignal = Signal()
     stateChanged = Signal(bool)
     htmlExportingFinished = Signal(bool, str)
-    removeExperiment = Signal()
+    statusInfoChanged = Signal()
 
     def __init__(self, parent=None, logic=None):  # , interface=None):
         super().__init__(parent)
@@ -20,7 +20,6 @@ class ProjectProxy(QObject):
         self.stateChanged.connect(self._onStateChanged)
         self.logic.projectCreatedChanged.connect(self.projectCreatedChanged)
         self.logic.projectInfoChanged.connect(self.projectInfoChanged)
-        self.logic.removeExperiment.connect(self.removeExperiment)
 
     @Property('QVariant', notify=projectInfoChanged)
     def projectInfoAsJson(self):
@@ -101,7 +100,7 @@ class ProjectProxy(QObject):
     @Slot()
     def resetState(self):
         self.logic.resetState()
-        self.removeExperiment.emit()
+        self.parent.experiment.removeExperiment()
         self.logic.stateHasChanged(False)
         self.stateChanged.emit(False)
 
@@ -132,3 +131,11 @@ class ProjectProxy(QObject):
         success = self.logic.saveReport(filepath)
         self.htmlExportingFinished.emit(success, filepath)
 
+    # status
+    @Property('QVariant', notify=statusInfoChanged)
+    def statusModelAsObj(self):
+        return self.logic.statusModelAsObj()
+
+    @Property(str, notify=statusInfoChanged)
+    def statusModelAsXml(self):
+        return self.logic.statusModelAsXml()

--- a/easyDiffractionApp/Logic/PyQmlProxy.py
+++ b/easyDiffractionApp/Logic/PyQmlProxy.py
@@ -20,9 +20,6 @@ from easyDiffractionApp.Logic.Proxies.Stack import StackProxy
 
 class PyQmlProxy(QObject):
 
-    # Status info
-    statusInfoChanged = Signal()
-
     # Misc
     dummySignal = Signal()
 
@@ -45,18 +42,6 @@ class PyQmlProxy(QObject):
         self._phase_proxy = PhaseProxy(self, logic=self.lc)
         self._experiment_proxy = ExperimentProxy(self, logic=self.lc)
         self._sample_proxy = SampleProxy(self, logic=self.lc)
-
-        ################## signals from other proxies #################
-        self._fitting_proxy.currentCalculatorChanged.connect(self.statusInfoChanged)
-        self._fitting_proxy.currentMinimizerChanged.connect(self.statusInfoChanged)
-        self._fitting_proxy.currentMinimizerMethodChanged.connect(self.statusInfoChanged)
-        self._project_proxy.removeExperiment.connect(self._experiment_proxy.removeExperiment)
-        self._phase_proxy.stateChanged.connect(self._project_proxy.stateChanged)
-        self._phase_proxy.projectInfoChanged.connect(self._project_proxy.projectInfoChanged)
-        # Constraints
-        self._fitting_proxy.constraintsModified.connect(self._parameters_proxy._setParametersAsObj)
-        self._fitting_proxy.constraintsModified.connect(self._parameters_proxy._setParametersAsXml)
-        self._fitting_proxy.constraintsModified.connect(self._parameters_proxy._onSimulationParametersChanged)
 
         # start the undo/redo stack
         self.lc.initializeBorg()
@@ -116,15 +101,6 @@ class PyQmlProxy(QObject):
     @Property('QVariant', notify=dummySignal)
     def parameters(self):
         return self._parameters_proxy
-
-    # status
-    @Property('QVariant', notify=statusInfoChanged)
-    def statusModelAsObj(self):
-        return self.lc.statusModelAsObj()
-
-    @Property(str, notify=statusInfoChanged)
-    def statusModelAsXml(self):
-        return self.lc.statusModelAsXml()
 
     # screen recorder
     @Property('QVariant', notify=dummySignal)

--- a/easyDiffractionApp/Logic/PyQmlProxy.py
+++ b/easyDiffractionApp/Logic/PyQmlProxy.py
@@ -19,9 +19,6 @@ from easyDiffractionApp.Logic.Proxies.Stack import StackProxy
 
 
 class PyQmlProxy(QObject):
-    # SIGNALS
-    currentCalculatorChanged = Signal()
-    parametersChanged = Signal()
 
     # Status info
     statusInfoChanged = Signal()
@@ -50,8 +47,7 @@ class PyQmlProxy(QObject):
         self._sample_proxy = SampleProxy(self, logic=self.lc)
 
         ################## signals from other proxies #################
-        self.parametersChanged.connect(self.lc.parametersChanged)
-        self.currentCalculatorChanged.connect(self.statusInfoChanged)
+        self._fitting_proxy.currentCalculatorChanged.connect(self.statusInfoChanged)
         self._fitting_proxy.currentMinimizerChanged.connect(self.statusInfoChanged)
         self._fitting_proxy.currentMinimizerMethodChanged.connect(self.statusInfoChanged)
         self._project_proxy.removeExperiment.connect(self._experiment_proxy.removeExperiment)

--- a/easyDiffractionApp/Logic/PyQmlProxy.py
+++ b/easyDiffractionApp/Logic/PyQmlProxy.py
@@ -55,6 +55,8 @@ class PyQmlProxy(QObject):
         self._fitting_proxy.currentMinimizerChanged.connect(self.statusInfoChanged)
         self._fitting_proxy.currentMinimizerMethodChanged.connect(self.statusInfoChanged)
         self._project_proxy.removeExperiment.connect(self._experiment_proxy.removeExperiment)
+        self._phase_proxy.stateChanged.connect(self._project_proxy.stateChanged)
+        self._phase_proxy.projectInfoChanged.connect(self._project_proxy.projectInfoChanged)
         # Constraints
         self._fitting_proxy.constraintsModified.connect(self._parameters_proxy._setParametersAsObj)
         self._fitting_proxy.constraintsModified.connect(self._parameters_proxy._setParametersAsXml)

--- a/easyDiffractionApp/Logic/PyQmlProxy.py
+++ b/easyDiffractionApp/Logic/PyQmlProxy.py
@@ -45,8 +45,8 @@ class PyQmlProxy(QObject):
         self._stack_proxy = StackProxy(self, logic=self.lc)
         self._parameters_proxy = ParametersProxy(self, logic=self.lc)
         self._project_proxy = ProjectProxy(self, logic=self.lc)
-        self._experiment_proxy = ExperimentProxy(self, logic=self.lc)
         self._phase_proxy = PhaseProxy(self, logic=self.lc)
+        self._experiment_proxy = ExperimentProxy(self, logic=self.lc)
         self._sample_proxy = SampleProxy(self, logic=self.lc)
 
         ################## signals from other proxies #################

--- a/easyDiffractionApp/Logic/Sample.py
+++ b/easyDiffractionApp/Logic/Sample.py
@@ -120,5 +120,5 @@ class SampleLogic(QObject):
 
         self._sample.interface = interface
         self.parent.phasesAsObjChanged()
-        self.parent.proxy.fitting.calculatorListChanged.emit()
+        self.parent.calculatorListChanged()
 

--- a/easyDiffractionApp/Logic/Sample.py
+++ b/easyDiffractionApp/Logic/Sample.py
@@ -20,7 +20,6 @@ class SampleLogic(QObject):
         super().__init__(parent)
         self.parent = parent
         self._interface = interface
-        self._phases = parent.l_phase
         self._sample = self._defaultCWSample()
 
     ####################################################################################################################
@@ -43,7 +42,7 @@ class SampleLogic(QObject):
 
     def _defaultCWSample(self):
         sample = Sample(
-            phases=self._phases.phases,
+            phases=self.parent.phases(),
             parameters=Instrument1DCWParameters(),
             pattern=Powder1DParameters(),
             interface=self._interface)
@@ -53,7 +52,7 @@ class SampleLogic(QObject):
     def _defaultCWPolSample(self):
         # sample = super()._defaultCWSample()
         sample = Sample(
-            phases=self._phases.phases,
+            phases=self.parent.phases(),
             parameters=Instrument1DCWPolParameters(),
             pattern=PolPowder1DParameters(),
             interface=self._interface)
@@ -64,7 +63,7 @@ class SampleLogic(QObject):
 
     def _defaultTOFSample(self):
         sample = Sample(
-            phases=self._phases.phases,
+            phases=self.parent.phases(),
             parameters=Instrument1DTOFParameters(),
             pattern=Powder1DParameters(),
             interface=self._interface)
@@ -120,6 +119,6 @@ class SampleLogic(QObject):
             interface.switch(interfaces[0])
 
         self._sample.interface = interface
-        self.parent.l_phase.phasesAsObjChanged.emit()
+        self.parent.phasesAsObjChanged()
         self.parent.proxy.fitting.calculatorListChanged.emit()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ python = '^3.8, <3.9'
 darkdetect = '^0.3.1'
 pyobjc-core = { version = '^7.1', platform = 'darwin' }
 pyobjc-framework-cocoa = { version = '^7.1', platform = 'darwin' }
+CFML = '^0.0.1'
+GSASII = '^0.0.1'
+
 # easyScience
 easyDiffraction = { git = 'https://github.com/easyScience/easyDiffractionLib.git', rev = 'master' }
 easyApp = { git = 'https://github.com/easyScience/easyApp.git', rev = 'master' }


### PR DESCRIPTION
Simplified signalling between proxies and logics.

proxy1 <-> PyQmlProxy <-> proxy2
logic1 <-> LogicController <-> logic2

but

proxy1 -> logic1 only

logic1 -> proxy2 must use signals to notify its own proxy, which in turn communicates with proxy2
logic1 -> logic2 must use LogicController and not call logic2 directly
