### PR TITLE
Update for profile calculations

### DIFF
--- a/easyDiffractionApp/Logic/Experiment.py
+++ b/easyDiffractionApp/Logic/Experiment.py
@@ -233,6 +233,7 @@ class ExperimentLogic(QObject):
         self._experiment_data_as_xml = dicttoxml(self.experiments, attr_type=True).decode()  # noqa: E501
 
     def addExperimentDataFromCif(self, file_url):
+        self.parent.shouldProfileBeCalculated = False # don't run update until we're done with setting parameters
         self._experiment_data = self._loadExperimentCif(file_url)
         self.newExperimentUpdate(file_url)
 
@@ -297,6 +298,7 @@ class ExperimentLogic(QObject):
 
         # notify parameter proxy
         params_json = json.dumps(self._experiment_parameters)
+        self.parent.shouldProfileBeCalculated = True # now we can run update
         self.parent.setSimulationParameters(params_json)
 
         if len(self.parent.sampleBackgrounds()) == 0:

--- a/easyDiffractionApp/Logic/LogicController.py
+++ b/easyDiffractionApp/Logic/LogicController.py
@@ -30,6 +30,7 @@ class LogicController(QObject):
         super().__init__(parent)
         self.proxy = parent
         self.interface = InterfaceFactory()
+        self.shouldProfileBeCalculated = True
 
         # Screen recorder
         self._screen_recorder = self.recorder()
@@ -137,8 +138,10 @@ class LogicController(QObject):
 
     def sendToExperiment(self, data, exp_name):
         self.setExperimentLoaded(True)
+        self.shouldProfileBeCalculated = False # don't calculate profile before all the loading took place
         self.setExperimentData(data)
         self.l_experiment.updateExperimentData(exp_name)
+        self.shouldProfileBeCalculated = True # now we can calculate profile
         self.updateBackgroundOnLoad()
         self.l_experiment.experimentLoadedChanged.emit()
 

--- a/easyDiffractionApp/Logic/LogicController.py
+++ b/easyDiffractionApp/Logic/LogicController.py
@@ -121,7 +121,9 @@ class LogicController(QObject):
         self.sample().output_index = self.l_phase._current_phase_index
 
     def resetState(self):
+        self.shouldProfileBeCalculated = False # setCurrentCalculatorIndex forces update
         self.l_fitting.setCurrentCalculatorIndex(0)
+        self.shouldProfileBeCalculated = True
         if self.l_phase.samplesPresent():
             self.l_phase.removeAllPhases()
         self.l_plotting1d.clearBackendState()

--- a/easyDiffractionApp/Logic/Parameters.py
+++ b/easyDiffractionApp/Logic/Parameters.py
@@ -362,6 +362,8 @@ class ParametersLogic(QObject):
     # Calculated data
     ####################################################################################################################
     def _updateCalculatedData(self):
+        if not self.parent.shouldProfileBeCalculated:
+            return
         if not self.parent.experimentLoaded() and not self.parent.experimentSkipped():
             return
 

--- a/easyDiffractionApp/Logic/Parameters.py
+++ b/easyDiffractionApp/Logic/Parameters.py
@@ -312,6 +312,7 @@ class ParametersLogic(QObject):
             self.undoRedoChanged.emit()
 
         else:
+            self.parent.shouldProfileBeCalculated = False
             if obj.raw_value == new_value:
                 return
             if isinstance(new_value, str):
@@ -321,6 +322,7 @@ class ParametersLogic(QObject):
             obj.error = 0.
             borg.stack.endMacro()
             self.parametersValuesChanged.emit()
+            self.parent.shouldProfileBeCalculated = True
             self._updateCalculatedData()
             self.parametersChanged.emit()
 


### PR DESCRIPTION
This PR addresses the issue of multiple calls to the profile calculator in case these are not needed.
Cases:
- load project
- load experiment cif
- modify parameter
- reset state

