### PR TITLE
Uninstaller shortcut.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,8 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-11, ubuntu-20.04, windows-2019]
+        os: [windows-2019]
+        # os: [macos-11, ubuntu-20.04, windows-2019]
 
     steps:
       - name: Cancel previous workflow runs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-2019]
-        # os: [macos-11, ubuntu-20.04, windows-2019]
+        os: [macos-11, ubuntu-20.04, windows-2019]
 
     steps:
       - name: Cancel previous workflow runs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ easyDiffraction = 'easyDiffractionApp.main:main'
 
 [release]
 app_name = 'EasyDiffraction'
+family_name = 'EasyScience'
 tag_template = 'v{VERSION}'
 title_template = 'Version {VERSION} ({DATE})'
 description_file = 'RELEASE.md'

--- a/tools/Scripts/Config.py
+++ b/tools/Scripts/Config.py
@@ -21,6 +21,7 @@ class Config():
         # Application
         self.app_version = self.__dict__['tool']['poetry']['version']
         self.app_name = self.__dict__['release']['app_name']
+        self.family_name = self.__dict__['release']['family_name']
         self.app_file_ext = self.__dict__['ci']['app']['setup']['file_ext'][self.os]
         self.app_full_name = f'{self.app_name}{self.app_file_ext}'
 

--- a/tools/Scripts/InstallerInstallScript.js
+++ b/tools/Scripts/InstallerInstallScript.js
@@ -84,9 +84,10 @@ Component.prototype.createOperations = function()
       "description=@ProductName@"
     )
        // Add shortcut for maintenance tool.
-       component.addOperation("CreateShortcut",
+       component.addOperation(
+       "CreateShortcut",
        "@TargetDir@/maintenancetool.exe",
-       "@StartMenuDir@/@ProductName@ Maintenance.lnk",
+       "@StartMenuDir@/@ProductName@/Uninstall.lnk",
        "workingDirectory=@TargetDir@",
        "iconPath=@TargetDir@/maintenancetool.exe",
        "iconId=0",

--- a/tools/Scripts/InstallerInstallScript.js
+++ b/tools/Scripts/InstallerInstallScript.js
@@ -87,7 +87,7 @@ Component.prototype.createOperations = function()
        component.addOperation(
        "CreateShortcut",
        "@TargetDir@/maintenancetool.exe",
-       "@StartMenuDir@/@ProductName@/Uninstall.lnk",
+       "@StartMenuDir@/@ProductName@/Maintenance Tool.lnk",
        "workingDirectory=@TargetDir@",
        "iconPath=@TargetDir@/maintenancetool.exe",
        "iconId=0",

--- a/tools/Scripts/InstallerInstallScript.js
+++ b/tools/Scripts/InstallerInstallScript.js
@@ -83,7 +83,15 @@ Component.prototype.createOperations = function()
       "iconPath=@TargetDir@/@ProductName@/@ProductName@.exe", "iconId=0",
       "description=@ProductName@"
     )
-
+       // Add shortcut for maintenance tool.
+       component.addOperation("CreateShortcut",
+       "@TargetDir@/maintenancetool.exe",
+       "@StartMenuDir@/@ProductName@ Maintenance.lnk",
+       "workingDirectory=@TargetDir@",
+       "iconPath=@TargetDir@/maintenancetool.exe",
+       "iconId=0",
+       "description=Update or remove@ProductName@");
+    }
     // Add start menu shortcut for the app uninstaller
     /*
     component.addOperation(

--- a/tools/Scripts/InstallerInstallScript.js
+++ b/tools/Scripts/InstallerInstallScript.js
@@ -92,7 +92,7 @@ Component.prototype.createOperations = function()
        "iconPath=@TargetDir@/maintenancetool.exe",
        "iconId=0",
        "description=Update or remove@ProductName@");
-    }
+
     // Add start menu shortcut for the app uninstaller
     /*
     component.addOperation(

--- a/tools/Scripts/MakeInstaller.py
+++ b/tools/Scripts/MakeInstaller.py
@@ -126,7 +126,7 @@ def installerConfigXml():
                 'WizardDefaultWidth': 900,
                 'WizardDefaultHeight': 600,
                 'StyleSheet': config_style,
-                'StartMenuDir': CONFIG.app_name,
+                'StartMenuDir' : CONFIG.family_name,
                 'TargetDir': CONFIG.installation_dir_for_qtifw,
                 #'CreateLocalRepository': 'true',
                 #'SaveDefaultRepositories': 'false',


### PR DESCRIPTION
Fixes #106 
This PR adds a shortcut to the maintenance tool. It is now created alongside the application shortcut in the EasyDiffraction startup subfolder. This is **WINDOWS ONLY**

Additionally, the top level folder is renamed to EasyScience as per comment in #106 