### PR TITLE
Default phase fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,27 +95,25 @@ jobs:
       - name: Create offline and online app installers from freezed app bundle
         run: python ${{ env.SCRIPTS_PATH }}/MakeInstaller.py
 
-      - name: Create zip archive of offline app installer for distribution
-        run: >
-          python ${{ env.SCRIPTS_PATH }}/ZipAppInstaller.py
-          ${{ env.BRANCH_NAME }}
-
       - name: Set up screen recording dependencies (macOS)
         if: runner.os == 'macOS'
         run: |
           "/Library/Application Support/VMware Tools/vmware-resolutionSet" 1920 1080
           system_profiler SPDisplaysDataType | grep Resolution
+
       - name: Set up screen recording dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
           sudo apt-get install libxkbcommon-x11-0
           Xvfb :0 -screen 0 1920x1080x24 -ac &
           echo "DISPLAY=:0" >> $GITHUB_ENV
+
       - name: Set up screen recording dependencies (Windows)
         if: runner.os == 'Windows'
         run: |
           Set-DisplayResolution -Width 1920 -Height 1080 -Force
           Get-DisplayResolution
+
       - name: Make dir for .desktop file (Linux)
         if: runner.os == 'Linux'
         run: mkdir -p ~/.local/share/applications/
@@ -138,6 +136,11 @@ jobs:
           ${{ env.BRANCH_NAME }}
           ${{ secrets.MACOS_CERTIFICATE_ENCODED }} ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
           ${{ secrets.APPSTORE_NOTARIZATION_USERNAME }} ${{ secrets.APPSTORE_NOTARIZATION_PASSWORD }}
+
+      - name: Create zip archive of offline app installer for distribution
+        run: >
+          python ${{ env.SCRIPTS_PATH }}/ZipAppInstaller.py
+          ${{ env.BRANCH_NAME }}
 
       - name: Upload zipped offline app installer to GitHub releases (non-master branch)
         if: github.event_name == 'push' && env.BRANCH_NAME != 'master'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-2019]
+        os: [macos-11, ubuntu-20.04, windows-2019]
 
     steps:
       - name: Cancel previous workflow runs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-11, ubuntu-20.04, windows-2019]
+        os: [windows-2019]
 
     steps:
       - name: Cancel previous workflow runs
@@ -95,48 +95,6 @@ jobs:
       - name: Create offline and online app installers from freezed app bundle
         run: python ${{ env.SCRIPTS_PATH }}/MakeInstaller.py
 
-      - name: Set up screen recording dependencies (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          "/Library/Application Support/VMware Tools/vmware-resolutionSet" 1920 1080
-          system_profiler SPDisplaysDataType | grep Resolution
-
-      - name: Set up screen recording dependencies (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get install libxkbcommon-x11-0
-          Xvfb :0 -screen 0 1920x1080x24 -ac &
-          echo "DISPLAY=:0" >> $GITHUB_ENV
-
-      - name: Set up screen recording dependencies (Windows)
-        if: runner.os == 'Windows'
-        run: |
-          Set-DisplayResolution -Width 1920 -Height 1080 -Force
-          Get-DisplayResolution
-
-      - name: Make dir for .desktop file (Linux)
-        if: runner.os == 'Linux'
-        run: mkdir -p ~/.local/share/applications/
-
-      - name: Install app
-        run: python ${{ env.SCRIPTS_PATH }}/InstallApp.py
-
-      - name: Run app in testmode, record screen and quit
-        run: python ${{ env.SCRIPTS_PATH }}/RunApp.py --testmode
-
-      - name: Rename test videos
-        run: >
-          python ${{ env.SCRIPTS_PATH }}/RenameTestVideos.py
-          ${{ env.BRANCH_NAME }}
-
-      - name: Sign app installer
-        if: github.event_name == 'push' && env.BRANCH_NAME == 'master'
-        run: >
-          python ${{ env.SCRIPTS_PATH }}/SignAppInstaller.py
-          ${{ env.BRANCH_NAME }}
-          ${{ secrets.MACOS_CERTIFICATE_ENCODED }} ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
-          ${{ secrets.APPSTORE_NOTARIZATION_USERNAME }} ${{ secrets.APPSTORE_NOTARIZATION_PASSWORD }}
-
       - name: Create zip archive of offline app installer for distribution
         run: >
           python ${{ env.SCRIPTS_PATH }}/ZipAppInstaller.py
@@ -151,28 +109,7 @@ jobs:
           allowUpdates: true
           replacesArtifacts: true
           token: ${{ secrets.GITHUB_TOKEN }}
-          artifacts: "${{ env.DISTRIBUTION_PATH }}/*.zip,${{ env.DISTRIBUTION_PATH }}/*.mp4"
+          artifacts: "${{ env.DISTRIBUTION_PATH }}/*.zip"
           tag: ${{ env.BRANCH_NAME }}
           name: ${{ env.BRANCH_NAME }}
           bodyFile: "RELEASE.md"
-
-      - name: Upload zipped offline app installer to GitHub releases (master branch)
-        if: github.event_name == 'push' && env.BRANCH_NAME == 'master'
-        uses: ncipollo/release-action@v1
-        with:
-          draft: true
-          prerelease: true
-          allowUpdates: true
-          replacesArtifacts: true
-          token: ${{ secrets.GITHUB_TOKEN }}
-          artifacts: "${{ env.DISTRIBUTION_PATH }}/*.zip"
-          tag: ${{ env.RELEASE_TAG }}
-          name: ${{ env.RELEASE_TITLE }}
-          bodyFile: "RELEASE.md"
-
-      - name: Upload online app installer to repository via FTP
-        if: github.event_name == 'push'
-        run: >
-          python ${{ env.SCRIPTS_PATH }}/UploadToFtp.py
-          ${{ env.BRANCH_NAME }}
-          ${{ secrets.APP_REPO_FTP_PASSWORD }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,6 +100,45 @@ jobs:
           python ${{ env.SCRIPTS_PATH }}/ZipAppInstaller.py
           ${{ env.BRANCH_NAME }}
 
+      - name: Set up screen recording dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          "/Library/Application Support/VMware Tools/vmware-resolutionSet" 1920 1080
+          system_profiler SPDisplaysDataType | grep Resolution
+      - name: Set up screen recording dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get install libxkbcommon-x11-0
+          Xvfb :0 -screen 0 1920x1080x24 -ac &
+          echo "DISPLAY=:0" >> $GITHUB_ENV
+      - name: Set up screen recording dependencies (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          Set-DisplayResolution -Width 1920 -Height 1080 -Force
+          Get-DisplayResolution
+      - name: Make dir for .desktop file (Linux)
+        if: runner.os == 'Linux'
+        run: mkdir -p ~/.local/share/applications/
+
+      - name: Install app
+        run: python ${{ env.SCRIPTS_PATH }}/InstallApp.py
+
+      - name: Run app in testmode, record screen and quit
+        run: python ${{ env.SCRIPTS_PATH }}/RunApp.py --testmode
+
+      - name: Rename test videos
+        run: >
+          python ${{ env.SCRIPTS_PATH }}/RenameTestVideos.py
+          ${{ env.BRANCH_NAME }}
+
+      - name: Sign app installer
+        if: github.event_name == 'push' && env.BRANCH_NAME == 'master'
+        run: >
+          python ${{ env.SCRIPTS_PATH }}/SignAppInstaller.py
+          ${{ env.BRANCH_NAME }}
+          ${{ secrets.MACOS_CERTIFICATE_ENCODED }} ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+          ${{ secrets.APPSTORE_NOTARIZATION_USERNAME }} ${{ secrets.APPSTORE_NOTARIZATION_PASSWORD }}
+
       - name: Upload zipped offline app installer to GitHub releases (non-master branch)
         if: github.event_name == 'push' && env.BRANCH_NAME != 'master'
         uses: ncipollo/release-action@v1
@@ -109,7 +148,28 @@ jobs:
           allowUpdates: true
           replacesArtifacts: true
           token: ${{ secrets.GITHUB_TOKEN }}
-          artifacts: "${{ env.DISTRIBUTION_PATH }}/*.zip"
+          artifacts: "${{ env.DISTRIBUTION_PATH }}/*.zip,${{ env.DISTRIBUTION_PATH }}/*.mp4"
           tag: ${{ env.BRANCH_NAME }}
           name: ${{ env.BRANCH_NAME }}
           bodyFile: "RELEASE.md"
+
+      - name: Upload zipped offline app installer to GitHub releases (master branch)
+        if: github.event_name == 'push' && env.BRANCH_NAME == 'master'
+        uses: ncipollo/release-action@v1
+        with:
+          draft: true
+          prerelease: true
+          allowUpdates: true
+          replacesArtifacts: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts: "${{ env.DISTRIBUTION_PATH }}/*.zip"
+          tag: ${{ env.RELEASE_TAG }}
+          name: ${{ env.RELEASE_TITLE }}
+          bodyFile: "RELEASE.md"
+
+      - name: Upload online app installer to repository via FTP
+        if: github.event_name == 'push'
+        run: >
+          python ${{ env.SCRIPTS_PATH }}/UploadToFtp.py
+          ${{ env.BRANCH_NAME }}
+          ${{ secrets.APP_REPO_FTP_PASSWORD }}

--- a/tools/Scripts/FreezeApp.py
+++ b/tools/Scripts/FreezeApp.py
@@ -10,7 +10,7 @@ import glob
 import site
 import PySide2, shiboken2
 import cryspy, GSASII
-import easyCore, easyCrystallography, easyDiffractionLib, easyApp
+import easyCore, easyCrystallography, easyDiffractionLib, easyApp, periodictable
 import Functions, Config
 from PyInstaller.__main__ import run as pyInstallerMain
 
@@ -39,6 +39,7 @@ def excludedModules():
 
 def addedData():
     # Add main data
+    pt_data = os.path.join(periodictable.__path__[0], 'xsf')
     data = [{'from': CONFIG.package_name, 'to': CONFIG.package_name},
             {'from': cryspy.__path__[0], 'to': 'cryspy'},
             {'from': GSASII.__path__[0], 'to': '.'},
@@ -46,6 +47,7 @@ def addedData():
             {'from': easyDiffractionLib.__path__[0], 'to': 'easyDiffractionLib'},
             {'from': easyCrystallography.__path__[0], 'to': 'easyCrystallography'},
             {'from': easyApp.__path__[0], 'to': 'easyApp'},
+            {'from': pt_data, 'to': 'periodictable-data'},
             {'from': 'utils.py', 'to': '.'},
             {'from': 'pyproject.toml', 'to': '.'}]
     # Add other missing libs

--- a/tools/Scripts/FreezeApp.py
+++ b/tools/Scripts/FreezeApp.py
@@ -9,8 +9,9 @@ import os, sys
 import glob
 import site
 import PySide2, shiboken2
+import periodictable
 import cryspy, GSASII
-import easyCore, easyCrystallography, easyDiffractionLib, easyApp, periodictable
+import easyCore, easyCrystallography, easyDiffractionLib, easyApp
 import Functions, Config
 from PyInstaller.__main__ import run as pyInstallerMain
 

--- a/tools/Scripts/FreezeApp.py
+++ b/tools/Scripts/FreezeApp.py
@@ -141,7 +141,7 @@ def runPyInstaller():
             '--log-level', 'WARN',                  # LEVEL may be one of DEBUG, INFO, WARN, ERROR, CRITICAL (default: INFO).
             '--noconfirm',                          # Replace output directory (default: SPECPATH/dist/SPECNAME) without asking for confirmation
             '--clean',                              # Clean PyInstaller cache and remove temporary files before building
-            # '--windowed',                           # Windows and Mac OS X: do not provide a console window for standard i/o.
+            '--windowed',                           # Windows and Mac OS X: do not provide a console window for standard i/o.
             '--onedir',                             # Create a one-folder bundle containing an executable (default)
             #'--specpath', workDirPath(),           # Folder to store the generated spec file (default: current directory)
             '--distpath', CONFIG.dist_dir,          # Where to put the bundled app (default: ./dist)

--- a/tools/Scripts/FreezeApp.py
+++ b/tools/Scripts/FreezeApp.py
@@ -133,10 +133,10 @@ def runPyInstaller():
         pyInstallerMain([
             main_py_path,                           # Application main file
             f'--name={CONFIG.app_name}',            # Name to assign to the bundled app and spec file (default: first script’s basename)
-            '--log-level', 'WARN',                  # LEVEL may be one of DEBUG, INFO, WARN, ERROR, CRITICAL (default: INFO).
+            '--log-level', 'DEBUG',                  # LEVEL may be one of DEBUG, INFO, WARN, ERROR, CRITICAL (default: INFO).
             '--noconfirm',                          # Replace output directory (default: SPECPATH/dist/SPECNAME) without asking for confirmation
             '--clean',                              # Clean PyInstaller cache and remove temporary files before building
-            '--windowed',                           # Windows and Mac OS X: do not provide a console window for standard i/o.
+            # '--windowed',                           # Windows and Mac OS X: do not provide a console window for standard i/o.
             '--onedir',                             # Create a one-folder bundle containing an executable (default)
             #'--specpath', workDirPath(),           # Folder to store the generated spec file (default: current directory)
             '--distpath', CONFIG.dist_dir,          # Where to put the bundled app (default: ./dist)

--- a/tools/Scripts/FreezeApp.py
+++ b/tools/Scripts/FreezeApp.py
@@ -133,7 +133,7 @@ def runPyInstaller():
         pyInstallerMain([
             main_py_path,                           # Application main file
             f'--name={CONFIG.app_name}',            # Name to assign to the bundled app and spec file (default: first script’s basename)
-            '--log-level', 'DEBUG',                  # LEVEL may be one of DEBUG, INFO, WARN, ERROR, CRITICAL (default: INFO).
+            '--log-level', 'WARN',                  # LEVEL may be one of DEBUG, INFO, WARN, ERROR, CRITICAL (default: INFO).
             '--noconfirm',                          # Replace output directory (default: SPECPATH/dist/SPECNAME) without asking for confirmation
             '--clean',                              # Clean PyInstaller cache and remove temporary files before building
             # '--windowed',                           # Windows and Mac OS X: do not provide a console window for standard i/o.

--- a/tools/Scripts/FreezeApp.py
+++ b/tools/Scripts/FreezeApp.py
@@ -39,8 +39,6 @@ def excludedModules():
 
 def addedData():
     # Add main data
-    pt_data = os.path.join(periodictable.__path__[0], 'xsf')
-    pt_data_target = os.path.join('periodictable-data', 'xsf')
     data = [{'from': CONFIG.package_name, 'to': CONFIG.package_name},
             {'from': cryspy.__path__[0], 'to': 'cryspy'},
             {'from': GSASII.__path__[0], 'to': '.'},
@@ -63,6 +61,10 @@ def addedData():
         for lib_name in missing_calculator_libs:
             lib_path = os.path.join(site_packages_path, lib_name)
             data.append({'from': lib_path, 'to': lib_name})
+    # Add missing module data (e.g. periodictable data)
+    pt_data = os.path.join(periodictable.__path__[0], 'xsf')
+    pt_data_target = os.path.join('periodictable-data', 'xsf')
+    data.append({'from': pt_data, 'to': pt_data_target})
     # Format for pyinstaller  
     separator = CONFIG['ci']['pyinstaller']['separator'][CONFIG.os]
     formatted = []

--- a/tools/Scripts/FreezeApp.py
+++ b/tools/Scripts/FreezeApp.py
@@ -46,7 +46,6 @@ def addedData():
             {'from': easyDiffractionLib.__path__[0], 'to': 'easyDiffractionLib'},
             {'from': easyCrystallography.__path__[0], 'to': 'easyCrystallography'},
             {'from': easyApp.__path__[0], 'to': 'easyApp'},
-            {'from': pt_data, 'to': pt_data_target},
             {'from': 'utils.py', 'to': '.'},
             {'from': 'pyproject.toml', 'to': '.'}]
     # Add other missing libs

--- a/tools/Scripts/FreezeApp.py
+++ b/tools/Scripts/FreezeApp.py
@@ -40,6 +40,7 @@ def excludedModules():
 def addedData():
     # Add main data
     pt_data = os.path.join(periodictable.__path__[0], 'xsf')
+    pt_data_target = os.path.join('periodictable-data', 'xsf')
     data = [{'from': CONFIG.package_name, 'to': CONFIG.package_name},
             {'from': cryspy.__path__[0], 'to': 'cryspy'},
             {'from': GSASII.__path__[0], 'to': '.'},
@@ -47,7 +48,7 @@ def addedData():
             {'from': easyDiffractionLib.__path__[0], 'to': 'easyDiffractionLib'},
             {'from': easyCrystallography.__path__[0], 'to': 'easyCrystallography'},
             {'from': easyApp.__path__[0], 'to': 'easyApp'},
-            {'from': pt_data, 'to': 'periodictable-data'},
+            {'from': pt_data, 'to': pt_data_target},
             {'from': 'utils.py', 'to': '.'},
             {'from': 'pyproject.toml', 'to': '.'}]
     # Add other missing libs


### PR DESCRIPTION
This fixes the issue of ephemeric failure of loading a phase into EDA, visible on GH hosts and occasionally locally.

`periodictable` dependency requires data files in specific place.
This is being used on every structure load and I've no idea why this wasn't happening earlier.

The standard way to specify missing data is to add the definitions to the project toml file.
However, I couldn't find a way to query `site-packages` location in toml, so had to add some logic to the freeze script.
