### PR TITLE
Patch for 0.8.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    timeout-minutes: 40
+    timeout-minutes: 60
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
extend the build process timeout to allow extra tasks, like code signing